### PR TITLE
Fix GitHub Pages OAuth build configuration

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -41,6 +41,8 @@ jobs:
         working-directory: admin
         env:
           VITE_PROXY_URL: ${{ vars.VITE_PROXY_URL || 'https://een-oauth-proxy.klaushofrichter.workers.dev' }}
+          VITE_EEN_CLIENT_ID: ${{ secrets.VITE_EEN_CLIENT_ID }}
+          VITE_REDIRECT_URI: 'https://klaushofrichter.github.io/een-oauth-proxy/'
 
       - name: Setup Pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
## Summary

- Add `VITE_EEN_CLIENT_ID` secret to GitHub Pages build
- Add `VITE_REDIRECT_URI` for proper OAuth callback to GitHub Pages URL

## Required Setup

After merging, ensure the following repository secret is configured:
- `VITE_EEN_CLIENT_ID` - Your EEN OAuth client ID

Also ensure your EEN application has `https://klaushofrichter.github.io/een-oauth-proxy/` as an allowed redirect URI.

## Test plan

- [ ] Add repository secret `VITE_EEN_CLIENT_ID`
- [ ] Merge PR and verify GitHub Pages deployment
- [ ] Test OAuth login on deployed app

🤖 Generated with [Claude Code](https://claude.com/claude-code)