### PR TITLE
Fix duplicate env block in pr-review workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Run Claude Code Review
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get the diff for this PR
           git diff origin/${{ github.base_ref }}...HEAD > pr_diff.txt
@@ -45,5 +46,3 @@ jobs:
             cat review_output.txt >> comment.md
             gh pr comment ${{ github.event.pull_request.number }} --body-file comment.md
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fix YAML syntax error in pr-review.yml - merged duplicate `env:` blocks into one.

## Test plan

- [ ] Workflow should no longer fail with "'env' is already defined" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)