### PR TITLE
Remove trailing slash from redirect URI

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           VITE_PROXY_URL: ${{ vars.VITE_PROXY_URL || 'https://een-oauth-proxy.klaushofrichter.workers.dev' }}
           VITE_EEN_CLIENT_ID: ${{ secrets.VITE_EEN_CLIENT_ID }}
-          VITE_REDIRECT_URI: 'https://klaushofrichter.github.io/een-oauth-proxy/'
+          VITE_REDIRECT_URI: 'https://klaushofrichter.github.io/een-oauth-proxy'
 
       - name: Setup Pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
## Summary

Fix OAuth redirect_uri to match EEN configuration (without trailing slash).

## Test plan

- [ ] OAuth login should work on GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)