### PR TITLE
Limit proxy options to Cloudflare in production

### DIFF
--- a/.github/workflows/test-admin.yml
+++ b/.github/workflows/test-admin.yml
@@ -1,0 +1,64 @@
+name: Test Admin App
+
+on:
+  pull_request:
+    branches:
+      - production
+      - develop
+    paths:
+      - 'admin/**'
+      - '.github/workflows/test-admin.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: admin/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: admin
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium
+        working-directory: admin
+
+      - name: Build admin app
+        run: npm run build
+        working-directory: admin
+        env:
+          VITE_PROXY_URL: 'https://een-oauth-proxy.klaushofrichter.workers.dev'
+          VITE_EEN_CLIENT_ID: ${{ secrets.VITE_EEN_CLIENT_ID }}
+          VITE_REDIRECT_URI: 'http://127.0.0.1:3333'
+
+      - name: Run tests against Cloudflare proxy
+        run: npm test
+        working-directory: admin
+        env:
+          VITE_PROXY_URL: 'https://een-oauth-proxy.klaushofrichter.workers.dev'
+          ADMIN_TEST_USER: ${{ secrets.ADMIN_TEST_USER }}
+          ADMIN_TEST_PASSWORD: ${{ secrets.ADMIN_TEST_PASSWORD }}
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: admin/playwright-report/
+          retention-days: 7
+
+      - name: Upload test screenshots
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: test-screenshots
+          path: admin/test-results/
+          retention-days: 7

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-admin",
   "displayName": "EEN OAuth Proxy Admin",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/admin/src/services/admin.js
+++ b/admin/src/services/admin.js
@@ -4,19 +4,32 @@
 
 const STORAGE_KEY = 'een_proxy_url'
 const ENV_PROXY_URL = import.meta.env.VITE_PROXY_URL
-const DEFAULT_PROXY_URL = ENV_PROXY_URL || 'http://localhost:8787'
-
-// Base predefined proxy options
-const BASE_PROXY_OPTIONS = [
-  { label: 'Local (localhost:8787)', value: 'http://localhost:8787' },
-  { label: 'Cloudflare (Workers)', value: 'https://een-oauth-proxy.klaushofrichter.workers.dev' }
-]
+const CLOUDFLARE_PROXY_URL = 'https://een-oauth-proxy.klaushofrichter.workers.dev'
+const LOCAL_PROXY_URL = 'http://localhost:8787'
+const DEFAULT_PROXY_URL = ENV_PROXY_URL || LOCAL_PROXY_URL
 
 /**
- * Get available proxy options (includes env variable URL if different from predefined)
+ * Check if running in production (GitHub Pages)
+ */
+function isProduction() {
+  return window.location.hostname.includes('github.io')
+}
+
+/**
+ * Get available proxy options based on environment
+ * - In production: only Cloudflare (and custom env if different)
+ * - In development: both local and Cloudflare options
  */
 export function getProxyOptions() {
-  const options = [...BASE_PROXY_OPTIONS]
+  const options = []
+
+  // In production, only show Cloudflare; in dev, show both
+  if (isProduction()) {
+    options.push({ label: 'Cloudflare (Workers)', value: CLOUDFLARE_PROXY_URL })
+  } else {
+    options.push({ label: 'Local (localhost:8787)', value: LOCAL_PROXY_URL })
+    options.push({ label: 'Cloudflare (Workers)', value: CLOUDFLARE_PROXY_URL })
+  }
 
   // Add env variable URL if it's different from predefined options
   if (ENV_PROXY_URL && !options.some((opt) => opt.value === ENV_PROXY_URL)) {
@@ -28,9 +41,19 @@ export function getProxyOptions() {
 
 /**
  * Get the configured proxy URL (from localStorage or default)
+ * In production, defaults to Cloudflare and ignores localhost if stored
  */
 export function getProxyUrl() {
   const stored = localStorage.getItem(STORAGE_KEY)
+
+  if (isProduction()) {
+    // In production, don't use localhost even if stored
+    if (!stored || stored === LOCAL_PROXY_URL) {
+      return CLOUDFLARE_PROXY_URL
+    }
+    return stored
+  }
+
   return stored || DEFAULT_PROXY_URL
 }
 


### PR DESCRIPTION
## Summary

- Detect production environment by checking for `github.io` hostname
- In production: only show Cloudflare proxy option (no localhost)
- Still show custom env URL if set to something different from Cloudflare
- Default to Cloudflare in production even if localhost was previously stored

## Test plan

- [x] All 16 local tests pass
- [ ] Verify production app only shows Cloudflare option in dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)