### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Create Release
+
+on:
+  workflow_run:
+    workflows: ["Test Deployed Admin App"]
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: production
+
+      - name: Get version numbers
+        id: versions
+        run: |
+          ADMIN_VERSION=$(node -p "require('./admin/package.json').version")
+          PROXY_VERSION=$(node -p "require('./proxy/package.json').version")
+          echo "admin_version=$ADMIN_VERSION" >> $GITHUB_OUTPUT
+          echo "proxy_version=$PROXY_VERSION" >> $GITHUB_OUTPUT
+          echo "release_tag=v${ADMIN_VERSION}" >> $GITHUB_OUTPUT
+          echo "Admin version: $ADMIN_VERSION"
+          echo "Proxy version: $PROXY_VERSION"
+
+      - name: Check if release already exists
+        id: check_release
+        run: |
+          if gh release view "${{ steps.versions.outputs.release_tag }}" > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Release ${{ steps.versions.outputs.release_tag }} already exists, skipping"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Release ${{ steps.versions.outputs.release_tag }} does not exist, will create"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create release archive
+        if: steps.check_release.outputs.exists == 'false'
+        run: |
+          ARCHIVE_NAME="een-oauth-proxy-${{ steps.versions.outputs.release_tag }}"
+          git archive --format=zip --prefix="${ARCHIVE_NAME}/" -o "${ARCHIVE_NAME}.zip" HEAD
+          git archive --format=tar.gz --prefix="${ARCHIVE_NAME}/" -o "${ARCHIVE_NAME}.tar.gz" HEAD
+          echo "Created ${ARCHIVE_NAME}.zip and ${ARCHIVE_NAME}.tar.gz"
+          ls -la *.zip *.tar.gz
+
+      - name: Create GitHub Release
+        if: steps.check_release.outputs.exists == 'false'
+        run: |
+          gh release create "${{ steps.versions.outputs.release_tag }}" \
+            --title "Release ${{ steps.versions.outputs.release_tag }}" \
+            --notes "## EEN OAuth Proxy Release
+
+          **Admin App Version:** ${{ steps.versions.outputs.admin_version }}
+          **Proxy Version:** ${{ steps.versions.outputs.proxy_version }}
+
+          ### Downloads
+          - \`een-oauth-proxy-${{ steps.versions.outputs.release_tag }}.zip\` - ZIP archive
+          - \`een-oauth-proxy-${{ steps.versions.outputs.release_tag }}.tar.gz\` - TAR.GZ archive
+
+          ### Deployed URLs
+          - **Admin App:** https://klaushofrichter.github.io/een-oauth-proxy
+          - **Proxy:** https://een-oauth-proxy.klaushofrichter.workers.dev
+          " \
+            "een-oauth-proxy-${{ steps.versions.outputs.release_tag }}.zip" \
+            "een-oauth-proxy-${{ steps.versions.outputs.release_tag }}.tar.gz"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          if [ "${{ steps.check_release.outputs.exists }}" == "true" ]; then
+            echo "### ⏭️ Release Skipped" >> $GITHUB_STEP_SUMMARY
+            echo "Release ${{ steps.versions.outputs.release_tag }} already exists." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### ✅ Release Created" >> $GITHUB_STEP_SUMMARY
+            echo "**Tag:** ${{ steps.versions.outputs.release_tag }}" >> $GITHUB_STEP_SUMMARY
+            echo "**Admin Version:** ${{ steps.versions.outputs.admin_version }}" >> $GITHUB_STEP_SUMMARY
+            echo "**Proxy Version:** ${{ steps.versions.outputs.proxy_version }}" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/test-admin-deployed.yml
+++ b/.github/workflows/test-admin-deployed.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: admin
 
       - name: Run tests against Cloudflare proxy
-        run: npm test
+        run: npx playwright test -x
         working-directory: admin
         env:
           VITE_PROXY_URL: 'https://een-oauth-proxy.klaushofrichter.workers.dev'

--- a/.github/workflows/test-admin-deployed.yml
+++ b/.github/workflows/test-admin-deployed.yml
@@ -35,6 +35,8 @@ jobs:
         working-directory: admin
         env:
           VITE_PROXY_URL: 'https://een-oauth-proxy.klaushofrichter.workers.dev'
+          VITE_EEN_CLIENT_ID: ${{ secrets.VITE_EEN_CLIENT_ID }}
+          VITE_REDIRECT_URI: 'http://127.0.0.1:3333'
           ADMIN_TEST_USER: ${{ secrets.ADMIN_TEST_USER }}
           ADMIN_TEST_PASSWORD: ${{ secrets.ADMIN_TEST_PASSWORD }}
 

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-admin",
-  "version": "0.0.4",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-admin",
-      "version": "0.0.4",
+      "version": "0.0.7",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.25",

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-admin",
   "displayName": "EEN OAuth Proxy Admin",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-admin",
   "displayName": "EEN OAuth Proxy Admin",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/admin/tests/utils.js
+++ b/admin/tests/utils.js
@@ -92,11 +92,38 @@ export async function loginWithEEN(page, customPassword = null, credentials = nu
   // Wait for redirect to EEN
   await page.waitForURL(/.*eagleeyenetworks.com.*/, { timeout: 15000 })
   console.log('✅ Reached EEN signin page')
+  console.log(`📍 Current URL: ${page.url()}`)
 
-  // Fill email
+  // Wait a moment for page to fully load
+  await page.waitForTimeout(2000)
+
+  // Debug: log page title and check for common elements
+  const pageTitle = await page.title()
+  console.log(`📄 Page title: ${pageTitle}`)
+
+  // Fill email - try multiple selectors
   const emailInput = page.locator('#authentication--input__email')
-  await emailInput.waitFor({ state: 'visible', timeout: 15000 })
-  await emailInput.fill(username)
+  const emailInputAlt = page.locator('input[type="email"]')
+  const emailInputByPlaceholder = page.locator('input[placeholder*="email" i]')
+
+  let foundInput = null
+  for (const input of [emailInput, emailInputAlt, emailInputByPlaceholder]) {
+    if (await input.isVisible().catch(() => false)) {
+      foundInput = input
+      break
+    }
+  }
+
+  if (!foundInput) {
+    // Log page content for debugging
+    const bodyText = await page.locator('body').textContent().catch(() => 'Could not get body text')
+    console.log(`⚠️ Email input not found. Page content preview: ${bodyText.substring(0, 500)}`)
+    // Fall back to original selector with longer timeout
+    await emailInput.waitFor({ state: 'visible', timeout: 30000 })
+    foundInput = emailInput
+  }
+
+  await foundInput.fill(username)
   console.log('📧 Entered email')
 
   // Click next

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^16.4.7",

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Add a workflow that creates a GitHub release after successful deployment tests.

## Workflow Chain

```
PR to production
    → Claude Code Review
    → Merge
        → Deploy Admin to GitHub Pages (if admin/** changed)
            → Test Deployed Admin App
                → Create Release (NEW)
```

## Release Details

- **Trigger:** After "Test Deployed Admin App" succeeds
- **Version:** Uses admin app version (e.g., `v0.0.6`)
- **Archives:** ZIP and TAR.GZ of full repository
- **Skips:** If release already exists for that version

🤖 Generated with [Claude Code](https://claude.com/claude-code)