### PR TITLE
Add Slack notifications for deployments and releases

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -59,6 +59,82 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./admin/package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+      - name: Notify Slack
+        run: |
+          DEPLOY_TIME=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
+          APP_URL="https://klaushofrichter.github.io/een-oauth-proxy"
+
+          curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+            -H "Content-Type: application/json" \
+            -d @- << EOF
+          {
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "🌐 Admin App Deployed to Production",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Version:*\n${{ steps.version.outputs.version }}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Deployed:*\n${DEPLOY_TIME}"
+                  }
+                ]
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*Application URL:*\n<${APP_URL}|${APP_URL}>"
+                }
+              },
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "🔗 Open App",
+                      "emoji": true
+                    },
+                    "url": "${APP_URL}",
+                    "style": "primary"
+                  }
+                ]
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "Deployed via GitHub Actions • Workflow: Deploy Admin to GitHub Pages"
+                  }
+                ]
+              }
+            ]
+          }
+          EOF
+          echo "✅ Slack notification sent"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,91 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Notify Slack
+        if: steps.check_release.outputs.exists == 'false'
+        run: |
+          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${{ steps.versions.outputs.release_tag }}"
+          RELEASE_TIME=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
+
+          curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+            -H "Content-Type: application/json" \
+            -d @- << EOF
+          {
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "🚀 New Release: EEN OAuth Proxy ${{ steps.versions.outputs.release_tag }}",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Admin Version:*\n${{ steps.versions.outputs.admin_version }}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Proxy Version:*\n${{ steps.versions.outputs.proxy_version }}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Released:*\n${RELEASE_TIME}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Repository:*\n${{ github.repository }}"
+                  }
+                ]
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*Deployed URLs:*\n• <https://klaushofrichter.github.io/een-oauth-proxy|Admin App>\n• <https://een-oauth-proxy.klaushofrichter.workers.dev|OAuth Proxy>"
+                }
+              },
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "📦 View Release",
+                      "emoji": true
+                    },
+                    "url": "${RELEASE_URL}",
+                    "style": "primary"
+                  },
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "📋 Release Notes",
+                      "emoji": true
+                    },
+                    "url": "${RELEASE_URL}"
+                  }
+                ]
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "Triggered by GitHub Actions • Workflow: Create Release"
+                  }
+                ]
+              }
+            ]
+          }
+          EOF
+          echo "✅ Slack notification sent"
+
       - name: Summary
         run: |
           if [ "${{ steps.check_release.outputs.exists }}" == "true" ]; then


### PR DESCRIPTION
## Summary
- Add Slack notification when admin app is deployed to production (GitHub Pages)
- Add Slack notification when a new release is created
- Both messages include:
  - Version numbers
  - Timestamps
  - Links to deployed app / release
  - Action buttons

## Slack Message Examples

**Deployment notification:**
- Header: "🌐 Admin App Deployed to Production"
- Version and deploy time
- Link to open the app

**Release notification:**
- Header: "🚀 New Release: EEN OAuth Proxy vX.X.X"
- Admin and proxy versions
- Release time
- Links to deployed URLs
- Buttons to view release

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test deployment notification triggers on deploy
- [ ] Test release notification triggers on new release

🤖 Generated with [Claude Code](https://claude.com/claude-code)