### PR TITLE
Fix redirect_uri validation v1.1.4

### DIFF
--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^16.4.7",

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -169,8 +169,9 @@ async function handleGetAccessToken(url, request, env) {
   }
 
   // Validate redirect_uri domain against allowed origins (prevent open redirect attacks)
-  if (!isAllowedRedirectUri(redirectUri, env)) {
-    return jsonResponse({ error: 'Invalid redirect_uri: domain not allowed' }, 400)
+  const redirectValidation = validateRedirectUri(redirectUri, env)
+  if (!redirectValidation.valid) {
+    return jsonResponse({ error: redirectValidation.error }, 400)
   }
 
   // Exchange code for tokens with EEN
@@ -563,12 +564,9 @@ function getAllowedOrigins(env) {
     .map(o => o.trim())
     .filter(o => o.length > 0)
 
-  // In development, also allow localhost
+  // In development, also allow 127.0.0.1:3333 (EEN redirect URI)
   if (env.ENVIRONMENT === 'development') {
-    allowedOrigins.push(
-      'http://localhost:3333',
-      'http://127.0.0.1:3333'
-    )
+    allowedOrigins.push('http://127.0.0.1:3333')
   }
 
   return allowedOrigins
@@ -577,17 +575,25 @@ function getAllowedOrigins(env) {
 /**
  * Validate redirect_uri against allowed origins (prevent open redirect attacks)
  * The redirect_uri's origin must match one of the allowed origins
+ * @returns {Object} { valid: boolean, error?: string }
  */
-function isAllowedRedirectUri(redirectUri, env) {
+function validateRedirectUri(redirectUri, env) {
+  let url
   try {
-    const url = new URL(redirectUri)
-    const redirectOrigin = url.origin
-    const allowedOrigins = getAllowedOrigins(env)
-    return allowedOrigins.includes(redirectOrigin)
+    url = new URL(redirectUri)
   } catch (e) {
-    // Invalid URL
-    return false
+    // Invalid URL format
+    return { valid: false, error: 'Invalid redirect_uri: malformed URL' }
   }
+
+  const redirectOrigin = url.origin
+  const allowedOrigins = getAllowedOrigins(env)
+
+  if (!allowedOrigins.includes(redirectOrigin)) {
+    return { valid: false, error: 'Invalid redirect_uri: domain not allowed' }
+  }
+
+  return { valid: true }
 }
 
 /**

--- a/proxy/test/security.test.js
+++ b/proxy/test/security.test.js
@@ -494,7 +494,7 @@ describe('Security - Redirect URI Validation', () => {
 
     expect(response.status).toBe(400)
     const data = await response.json()
-    expect(data.error).toContain('domain not allowed')
+    expect(data.error).toContain('malformed URL')
   })
 
   it('should accept redirect_uri with allowed origin', async () => {


### PR DESCRIPTION
## Summary
Fixes issues identified in PR #34 code review:

| Priority | Issue | Fix |
|----------|-------|-----|
| Critical | Port mismatch (5173 vs 3333) | Use only 127.0.0.1:3333 in dev |
| Medium | Same error for different failures | Differentiate "malformed URL" vs "domain not allowed" |

## Changes
- `getAllowedOrigins()` now only adds `127.0.0.1:3333` in development (matches EEN redirect URI config)
- Renamed `isAllowedRedirectUri` to `validateRedirectUri` with structured return
- Returns specific error messages for debugging

## Test plan
- [x] 197 proxy unit tests pass
- [x] Admin tests pass against production (11 passed, 5 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)