### PR TITLE
Documentation and regression tests v1.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,7 +630,7 @@ For example, if you modify files in `proxy/`, the `proxy/package.json` version w
 
 ### "Forbidden: Invalid origin" error
 - Check that the request origin is in `ALLOWED_ORIGINS`
-- In development, localhost origins are automatically allowed
+- In development, only `http://127.0.0.1:3333` is automatically allowed (to match EEN OAuth redirect URI)
 
 ### "Admin access required" error
 - Ensure your email is in the `ADMIN_EMAILS` list
@@ -643,6 +643,18 @@ For example, if you modify files in `proxy/`, the `proxy/package.json` version w
 ### OAuth callback fails
 - Verify `VITE_REDIRECT_URI` matches your EEN OAuth app configuration
 - Check that the proxy is running and accessible
+
+## Breaking Changes
+
+### v1.1.4 - Development Origin Restriction
+
+**Change:** In development mode, only `http://127.0.0.1:3333` is now auto-allowed for redirect URIs and CORS origins. Previously, both `localhost:3333` and `127.0.0.1:3333` were allowed.
+
+**Reason:** EEN OAuth configuration requires the redirect URI to match exactly. Since EEN is configured for `http://127.0.0.1:3333`, using `localhost:3333` would fail OAuth callbacks even though they resolve to the same address.
+
+**Action Required:**
+- Ensure your local development setup uses `http://127.0.0.1:3333` (not `localhost:3333`)
+- If you need additional origins, add them to `ALLOWED_ORIGINS` in your `.dev.vars` file
 
 ## License
 

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^16.4.7",

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^16.4.7",

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^16.4.7",

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -565,6 +565,10 @@ function getAllowedOrigins(env) {
     .filter(o => o.length > 0)
 
   // In development, also allow 127.0.0.1:3333 (EEN redirect URI)
+  // Note: We intentionally do NOT allow localhost:3333 because EEN OAuth
+  // requires exact redirect URI match. Since EEN is configured for
+  // http://127.0.0.1:3333, using localhost would fail OAuth callbacks
+  // even though localhost and 127.0.0.1 resolve to the same address.
   if (env.ENVIRONMENT === 'development') {
     allowedOrigins.push('http://127.0.0.1:3333')
   }

--- a/proxy/test/security.test.js
+++ b/proxy/test/security.test.js
@@ -513,6 +513,7 @@ describe('Security - Redirect URI Validation', () => {
 
   it('should accept redirect_uri with 127.0.0.1:3333 in development', async () => {
     // 127.0.0.1:3333 is auto-allowed in development (matches EEN redirect URI)
+    // Note: This test requires ENVIRONMENT='development' in vitest.config.js
     const response = await fetchWithMetrics(
       'http://localhost/proxy/getAccessToken?code=test&redirect_uri=http://127.0.0.1:3333/callback',
       {
@@ -528,6 +529,8 @@ describe('Security - Redirect URI Validation', () => {
   it('should reject redirect_uri with localhost:3333 (not auto-allowed)', async () => {
     // Regression test: localhost:3333 is NOT auto-allowed, only 127.0.0.1:3333 is
     // This is because EEN OAuth requires exact redirect URI match
+    // Note: This test requires ENVIRONMENT='development' in vitest.config.js
+    // Error message format: 'Invalid redirect_uri: domain not allowed'
     const response = await fetchWithMetrics(
       'http://localhost/proxy/getAccessToken?code=test&redirect_uri=http://localhost:3333/callback',
       {

--- a/proxy/test/security.test.js
+++ b/proxy/test/security.test.js
@@ -498,7 +498,7 @@ describe('Security - Redirect URI Validation', () => {
   })
 
   it('should accept redirect_uri with allowed origin', async () => {
-    // In development mode, localhost:5173 is allowed
+    // localhost:5173 is allowed via ALLOWED_ORIGINS in vitest.config.js
     const response = await fetchWithMetrics(
       'http://localhost/proxy/getAccessToken?code=test&redirect_uri=http://localhost:5173/callback',
       {
@@ -509,6 +509,36 @@ describe('Security - Redirect URI Validation', () => {
 
     // Should not be rejected for domain (may fail at EEN for invalid code)
     expect(response.status).not.toBe(400)
+  })
+
+  it('should accept redirect_uri with 127.0.0.1:3333 in development', async () => {
+    // 127.0.0.1:3333 is auto-allowed in development (matches EEN redirect URI)
+    const response = await fetchWithMetrics(
+      'http://localhost/proxy/getAccessToken?code=test&redirect_uri=http://127.0.0.1:3333/callback',
+      {
+        method: 'POST',
+        headers: { Origin: 'http://localhost:5173' }
+      }
+    )
+
+    // Should not be rejected for domain (may fail at EEN for invalid code)
+    expect(response.status).not.toBe(400)
+  })
+
+  it('should reject redirect_uri with localhost:3333 (not auto-allowed)', async () => {
+    // Regression test: localhost:3333 is NOT auto-allowed, only 127.0.0.1:3333 is
+    // This is because EEN OAuth requires exact redirect URI match
+    const response = await fetchWithMetrics(
+      'http://localhost/proxy/getAccessToken?code=test&redirect_uri=http://localhost:3333/callback',
+      {
+        method: 'POST',
+        headers: { Origin: 'http://localhost:5173' }
+      }
+    )
+
+    expect(response.status).toBe(400)
+    const data = await response.json()
+    expect(data.error).toContain('domain not allowed')
   })
 })
 

--- a/proxy/test/security.test.js
+++ b/proxy/test/security.test.js
@@ -530,7 +530,11 @@ describe('Security - Redirect URI Validation', () => {
     // Regression test: localhost:3333 is NOT auto-allowed, only 127.0.0.1:3333 is
     // This is because EEN OAuth requires exact redirect URI match
     // Note: This test requires ENVIRONMENT='development' in vitest.config.js
-    // Error message format: 'Invalid redirect_uri: domain not allowed'
+    //
+    // Important: We use a valid Origin (localhost:5173 from ALLOWED_ORIGINS in vitest.config.js)
+    // to ensure we're testing redirect_uri validation, not origin validation.
+    // - Origin rejection = 403 Forbidden
+    // - redirect_uri rejection = 400 Bad Request with 'Invalid redirect_uri' error
     const response = await fetchWithMetrics(
       'http://localhost/proxy/getAccessToken?code=test&redirect_uri=http://localhost:3333/callback',
       {
@@ -539,8 +543,11 @@ describe('Security - Redirect URI Validation', () => {
       }
     )
 
+    // Verify it's a 400 (redirect_uri error), not 403 (origin error)
     expect(response.status).toBe(400)
     const data = await response.json()
+    // Verify error is specifically about redirect_uri, not origin
+    expect(data.error).toContain('redirect_uri')
     expect(data.error).toContain('domain not allowed')
   })
 })

--- a/proxy/vitest.config.js
+++ b/proxy/vitest.config.js
@@ -1,5 +1,14 @@
 import { defineWorkersConfig } from '@cloudflare/vitest-pool-workers/config'
 
+/**
+ * Vitest configuration for Cloudflare Workers tests
+ *
+ * IMPORTANT: Test environment requirements:
+ * - ENVIRONMENT must be 'development' for redirect URI validation tests to pass
+ *   (http://127.0.0.1:3333 is only auto-allowed in development mode)
+ * - ALLOWED_ORIGINS defines which origins pass CORS/redirect validation
+ * - If running in CI/CD, ensure these bindings match this configuration
+ */
 export default defineWorkersConfig({
   test: {
     setupFiles: ['./test/setup.js'],
@@ -12,7 +21,10 @@ export default defineWorkersConfig({
             CLIENT_ID: 'test-client-id',
             CLIENT_SECRET: 'test-client-secret',
             ADMIN_EMAILS: 'admin@example.com',
+            // Origins allowed for CORS and redirect_uri validation in tests
             ALLOWED_ORIGINS: 'http://localhost:5173',
+            // MUST be 'development' - some tests depend on auto-allowed origins
+            // (e.g., http://127.0.0.1:3333 regression test)
             ENVIRONMENT: 'development'
           }
         }


### PR DESCRIPTION
## Summary
Documents the breaking change from v1.1.4 and adds regression tests.

## Changes
- Add Breaking Changes section to README documenting v1.1.4 origin restriction
- Update troubleshooting section to clarify only `127.0.0.1:3333` is auto-allowed
- Add regression tests verifying `127.0.0.1:3333` is allowed but `localhost:3333` is not
- Add inline comment explaining why localhost is not auto-allowed (EEN exact match requirement)

## Test plan
- [x] 199 proxy unit tests pass
- [x] New regression tests verify correct behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)