### PR TITLE
Security improvements and developer experience v1.1.8

### DIFF
--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^16.4.7",

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -594,6 +594,14 @@ function validateRedirectUri(redirectUri, env) {
   const allowedOrigins = getAllowedOrigins(env)
 
   if (!allowedOrigins.includes(redirectOrigin)) {
+    // Check if this is a localhost vs 127.0.0.1 mismatch - provide helpful error
+    if (redirectOrigin.includes('localhost') &&
+        allowedOrigins.some(o => o.includes('127.0.0.1'))) {
+      return {
+        valid: false,
+        error: 'Invalid redirect_uri: use 127.0.0.1 instead of localhost (EEN requires exact match)'
+      }
+    }
     return { valid: false, error: 'Invalid redirect_uri: domain not allowed' }
   }
 

--- a/proxy/test/security.test.js
+++ b/proxy/test/security.test.js
@@ -546,9 +546,9 @@ describe('Security - Redirect URI Validation', () => {
     // Verify it's a 400 (redirect_uri error), not 403 (origin error)
     expect(response.status).toBe(400)
     const data = await response.json()
-    // Verify error is specifically about redirect_uri, not origin
+    // Verify error is specifically about redirect_uri with helpful localhost hint
     expect(data.error).toContain('redirect_uri')
-    expect(data.error).toContain('domain not allowed')
+    expect(data.error).toContain('127.0.0.1 instead of localhost')
   })
 })
 


### PR DESCRIPTION
## Summary
Multiple improvements to redirect_uri validation, test robustness, and developer experience.

## Changes

### v1.1.5 - Documentation
- Added Breaking Changes section to README documenting v1.1.4 origin restriction
- Updated troubleshooting section to clarify only `127.0.0.1:3333` is auto-allowed

### v1.1.6 - Test Environment Documentation
- Documented ENVIRONMENT requirement in vitest.config.js
- Added inline comments for test bindings

### v1.1.7 - Test Robustness
- Made redirect_uri regression test more robust
- Added explicit check that error contains 'redirect_uri' (not just 'domain not allowed')
- Prevents false positives if origin validation fails first

### v1.1.8 - Developer Experience
- Enhanced error message for localhost vs 127.0.0.1 mismatch
- Now shows: "use 127.0.0.1 instead of localhost (EEN requires exact match)"
- Helps developers immediately understand the issue

## Test plan
- [x] 199 proxy unit tests pass
- [x] Regression tests verify correct behavior for 127.0.0.1 vs localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)