### PR TITLE
Release workflow and security improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,14 @@ jobs:
         run: |
           ADMIN_VERSION=$(node -p "require('./admin/package.json').version")
           PROXY_VERSION=$(node -p "require('./proxy/package.json').version")
+          # Create combined release tag using both proxy and admin versions
+          RELEASE_TAG="proxy-v${PROXY_VERSION}_admin-v${ADMIN_VERSION}"
           echo "admin_version=$ADMIN_VERSION" >> $GITHUB_OUTPUT
           echo "proxy_version=$PROXY_VERSION" >> $GITHUB_OUTPUT
-          echo "release_tag=v${ADMIN_VERSION}" >> $GITHUB_OUTPUT
+          echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
           echo "Admin version: $ADMIN_VERSION"
           echo "Proxy version: $PROXY_VERSION"
+          echo "Release tag: $RELEASE_TAG"
 
       - name: Check if release already exists
         id: check_release
@@ -57,7 +60,7 @@ jobs:
         if: steps.check_release.outputs.exists == 'false'
         run: |
           gh release create "${{ steps.versions.outputs.release_tag }}" \
-            --title "Release ${{ steps.versions.outputs.release_tag }}" \
+            --title "Proxy v${{ steps.versions.outputs.proxy_version }} / Admin v${{ steps.versions.outputs.admin_version }}" \
             --notes "## EEN OAuth Proxy Release
 
           **Admin App Version:** ${{ steps.versions.outputs.admin_version }}
@@ -91,7 +94,7 @@ jobs:
                 "type": "header",
                 "text": {
                   "type": "plain_text",
-                  "text": "🚀 New Release: EEN OAuth Proxy ${{ steps.versions.outputs.release_tag }}",
+                  "text": "🚀 New Release: Proxy v${{ steps.versions.outputs.proxy_version }} / Admin v${{ steps.versions.outputs.admin_version }}",
                   "emoji": true
                 }
               },


### PR DESCRIPTION
## Summary
Updates release workflow to track both proxy and admin versions, plus security and DX improvements.

## Release Workflow Changes
- **Tag format**: Now `proxy-v1.1.8_admin-v1.0.5` (was `v1.0.5` admin-only)
- **Title format**: "Proxy v1.1.8 / Admin v1.0.5" 
- **Slack notification**: Shows both versions in header
- New release created when either proxy OR admin version changes

## Security & DX Improvements (v1.1.5 - v1.1.8)
- Breaking change documentation in README
- Test environment documentation in vitest.config.js
- More robust redirect_uri regression tests
- Helpful error message for localhost vs 127.0.0.1 mismatch

## Test plan
- [x] 199 proxy unit tests pass
- [ ] Verify release workflow creates correct tag format after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)