### PR TITLE
Fix PR #50 review concerns: heredoc variable interpolation and clickable proxy URL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,7 +161,7 @@ jobs:
 
           curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H "Content-Type: application/json" \
-            -d @- << 'EOF'
+            -d @- << EOF
           {
             "blocks": [
               {
@@ -197,7 +197,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "*Deployed URLs:*\n• <${ADMIN_APP_URL}|Admin App>\n• OAuth Proxy: ${{ vars.VITE_PROXY_URL }}"
+                  "text": "*Deployed URLs:*\n• <${ADMIN_APP_URL}|Admin App>\n• <${{ vars.VITE_PROXY_URL }}|OAuth Proxy>"
                 }
               },
               {


### PR DESCRIPTION
## Summary
This PR addresses the critical and low-priority concerns from PR #50 review.

## Changes

### Critical Fix
- **Fixed heredoc variable interpolation bug**: Changed `<< 'EOF'` to `<< EOF` (removed quotes) on line 164
  - The quoted heredoc was preventing GitHub Actions variables from being interpolated
  - This would have caused Slack messages to show literal `${{ ... }}` text instead of actual values
  - **Impact**: Without this fix, Slack notifications would be completely broken

### Low Priority Fix
- **Made OAuth Proxy URL clickable again**: Changed from plain text to clickable link
  - Before: `OAuth Proxy: ${{ vars.VITE_PROXY_URL }}`
  - After: `<${{ vars.VITE_PROXY_URL }}|OAuth Proxy>`
  - **Impact**: Better UX - users can click the proxy URL directly from Slack

## Testing
- ✅ No linting errors
- ✅ Syntax validated
- ✅ Variable interpolation will work correctly (GitHub Actions variables expand before heredoc is processed)

## Related
- Addresses concerns from PR #50 (develop → production) review
- Once merged to develop, PR #50 can be updated/merged with these fixes included