### PR TITLE
docs: update .env.example files to remove trailing slashes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ VITE_PROXY_URL=https://your-proxy.your-subdomain.workers.dev
 # EEN OAuth settings
 VITE_EEN_CLIENT_ID=your-een-client-id
 VITE_EEN_AUTH_URL=https://auth.eagleeyenetworks.com/oauth2/authorize
-VITE_REDIRECT_URI=https://your-username.github.io/een-oauth-proxy/demo1/
+VITE_REDIRECT_URI=https://your-username.github.io/een-oauth-proxy
 
 # ===========================================
 # Admin App Configuration (./admin/.env)
@@ -37,4 +37,4 @@ VITE_REDIRECT_URI=https://your-username.github.io/een-oauth-proxy/demo1/
 # EEN OAuth settings
 # VITE_EEN_CLIENT_ID=your-een-client-id
 # VITE_EEN_AUTH_URL=https://auth.eagleeyenetworks.com/oauth2/authorize
-# VITE_REDIRECT_URI=https://your-username.github.io/een-oauth-proxy/admin/
+# VITE_REDIRECT_URI=https://your-username.github.io/een-oauth-proxy

--- a/README.md
+++ b/README.md
@@ -391,6 +391,8 @@ VITE_PROXY_URL=https://your-proxy.your-subdomain.workers.dev
 VITE_REDIRECT_URI=https://your-username.github.io/een-oauth-proxy
 ```
 
+**Important:** The `VITE_REDIRECT_URI` must **exactly match** what's registered in your EEN OAuth application configuration, including the presence or absence of trailing slashes and paths. If not set, it defaults to `window.location.origin` (e.g., `https://your-username.github.io`).
+
 Then deploy:
 ```bash
 npm run deploy:pages

--- a/admin/.env.example
+++ b/admin/.env.example
@@ -12,8 +12,8 @@ VITE_EEN_AUTH_URL=https://auth.eagleeyenetworks.com/oauth2/authorize
 # Local development:
 VITE_REDIRECT_URI=http://127.0.0.1:3333
 
-# Production:
-# VITE_REDIRECT_URI=https://your-username.github.io/een-oauth-proxy/admin/
+# Production (must exactly match your EEN OAuth app configuration):
+# VITE_REDIRECT_URI=https://your-username.github.io/een-oauth-proxy
 
 # Test credentials for admin user (must be in ADMIN_EMAILS)
 ADMIN_TEST_USER=admin@example.com

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-admin",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-admin",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.25",

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-admin",
   "displayName": "EEN OAuth Proxy Admin",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/demo1/.env.example
+++ b/demo1/.env.example
@@ -12,5 +12,5 @@ VITE_EEN_AUTH_URL=https://auth.eagleeyenetworks.com/oauth2/authorize
 # Local development:
 VITE_REDIRECT_URI=http://127.0.0.1:3333
 
-# Production:
-# VITE_REDIRECT_URI=https://your-username.github.io/een-oauth-proxy/demo1/
+# Production (must exactly match your EEN OAuth app configuration):
+# VITE_REDIRECT_URI=https://your-username.github.io/een-oauth-proxy

--- a/demo1/package-lock.json
+++ b/demo1/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-demo1",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-demo1",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.25",

--- a/demo1/package.json
+++ b/demo1/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-demo1",
   "displayName": "EEN OAuth Demo",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Follow-up to PR #54 addressing code review feedback about documentation consistency.

### Changes
- Remove trailing slashes from redirect URI examples in all `.env.example` files
- Add clarification note about redirect URI exact matching in README deployment section
- Add comments in `.env.example` files noting URI must match EEN OAuth configuration

## Test plan
- [x] Documentation-only changes, no code changes
- [x] All examples now consistent with the code fix from PR #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)