### PR TITLE
fix: Fix critical variable definition placement issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
         run: |
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${{ steps.versions.outputs.release_tag }}"
           RELEASE_TIME=$(TZ='America/Chicago' date +"%Y-%m-%d %H:%M:%S CT")
-          ADMIN_APP_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/admin/"
+          ADMIN_APP_URL="${{ vars.VITE_REDIRECT_URI }}"
 
           curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H "Content-Type: application/json" \


### PR DESCRIPTION
This PR addresses a critical issue from the review of PR #50 regarding variable definition placement in the release workflow.

- Uses vars.VITE_REDIRECT_URI instead of constructing the URL dynamically.
- Ensures consistency with release notes.
- Avoids edge cases where github.event.repository.name might not be available.