### PR TITLE
fix: Admin App URL in Slack notifications

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -75,7 +75,6 @@ jobs:
       - name: Notify Slack
         run: |
           DEPLOY_TIME=$(TZ='America/Chicago' date +"%Y-%m-%d %H:%M:%S CT")
-          APP_URL="${{ vars.VITE_REDIRECT_URI }}"
 
           curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H "Content-Type: application/json" \
@@ -107,7 +106,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "*Application URL:*\n<${APP_URL}|${APP_URL}>"
+                  "text": "*Application URL:*\n<${{ vars.VITE_REDIRECT_URI }}|Admin App>"
                 }
               },
               {
@@ -120,7 +119,7 @@ jobs:
                       "text": "🔗 Open App",
                       "emoji": true
                     },
-                    "url": "${APP_URL}",
+                    "url": "${{ vars.VITE_REDIRECT_URI }}",
                     "style": "primary"
                   }
                 ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,6 @@ jobs:
         run: |
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${{ steps.versions.outputs.release_tag }}"
           RELEASE_TIME=$(TZ='America/Chicago' date +"%Y-%m-%d %H:%M:%S CT")
-          ADMIN_APP_URL="${{ vars.VITE_REDIRECT_URI }}"
 
           curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H "Content-Type: application/json" \
@@ -197,7 +196,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "*Deployed URLs:*\n• <${ADMIN_APP_URL}|Admin App>\n• <${{ vars.VITE_PROXY_URL }}|OAuth Proxy>"
+                  "text": "*Deployed URLs:*\n• <${{ vars.VITE_REDIRECT_URI }}|Admin App>\n• <${{ vars.VITE_PROXY_URL }}|OAuth Proxy>"
                 }
               },
               {


### PR DESCRIPTION
## Summary
- Fix Admin App URL not appearing in Slack notifications for releases
- Apply same fix to deploy-admin workflow for consistency

The shell variable `${ADMIN_APP_URL}` inside heredoc wasn't being expanded correctly in GitHub Actions, causing the URL to appear as `<|Admin App>` instead of a proper link.

**Solution:** Use `${{ vars.VITE_REDIRECT_URI }}` directly instead of assigning to a shell variable first.

## Files Changed
- `.github/workflows/release.yml` - Use GitHub Actions var directly for Admin App URL
- `.github/workflows/deploy-admin.yml` - Same fix for consistency

## Test plan
- [ ] Verify release workflow Slack message shows proper Admin App URL
- [ ] Verify deploy-admin workflow Slack message shows proper Admin App URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)