### PR TITLE
fix: use GitHub Actions vars directly in Slack notifications

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -75,7 +75,6 @@ jobs:
       - name: Notify Slack
         run: |
           DEPLOY_TIME=$(TZ='America/Chicago' date +"%Y-%m-%d %H:%M:%S CT")
-          APP_URL="${{ vars.VITE_REDIRECT_URI }}"
 
           curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H "Content-Type: application/json" \
@@ -107,7 +106,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "*Application URL:*\n<${APP_URL}|${APP_URL}>"
+                  "text": "*Application URL:*\n<${{ vars.VITE_REDIRECT_URI }}|Admin App>"
                 }
               },
               {
@@ -120,7 +119,7 @@ jobs:
                       "text": "🔗 Open App",
                       "emoji": true
                     },
-                    "url": "${APP_URL}",
+                    "url": "${{ vars.VITE_REDIRECT_URI }}",
                     "style": "primary"
                   }
                 ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,6 @@ jobs:
         run: |
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${{ steps.versions.outputs.release_tag }}"
           RELEASE_TIME=$(TZ='America/Chicago' date +"%Y-%m-%d %H:%M:%S CT")
-          ADMIN_APP_URL="${{ vars.VITE_REDIRECT_URI }}"
 
           curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H "Content-Type: application/json" \
@@ -197,7 +196,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "*Deployed URLs:*\n• <${ADMIN_APP_URL}|Admin App>\n• <${{ vars.VITE_PROXY_URL }}|OAuth Proxy>"
+                  "text": "*Deployed URLs:*\n• <${{ vars.VITE_REDIRECT_URI }}|Admin App>\n• <${{ vars.VITE_PROXY_URL }}|OAuth Proxy>"
                 }
               },
               {


### PR DESCRIPTION
## Summary
- Fixes Slack notification messages by using GitHub Actions `${{ vars.* }}` syntax directly in JSON payloads instead of shell variables
- Shell variables like `${APP_URL}` were not being properly interpolated inside the JSON payload
- This affects both `deploy-admin.yml` and `release.yml` workflows

## Test plan
- [ ] Trigger a deploy to verify Slack notifications show the correct Admin App URL
- [ ] Verify the release workflow Slack notification displays both deployed URLs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)