### PR TITLE
test: add direct access login test with captured token

### DIFF
--- a/demo1/package-lock.json
+++ b/demo1/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-demo1",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-demo1",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.25",

--- a/demo1/package-lock.json
+++ b/demo1/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-demo1",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-demo1",
-      "version": "0.0.21",
+      "version": "0.0.22",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.25",

--- a/demo1/package-lock.json
+++ b/demo1/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-demo1",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-demo1",
-      "version": "0.0.22",
+      "version": "0.0.23",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.25",

--- a/demo1/package.json
+++ b/demo1/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-demo1",
   "displayName": "EEN OAuth Demo",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "private": true,
   "type": "module",
   "scripts": {

--- a/demo1/package.json
+++ b/demo1/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-demo1",
   "displayName": "EEN OAuth Demo",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/demo1/package.json
+++ b/demo1/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-demo1",
   "displayName": "EEN OAuth Demo",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "private": true,
   "type": "module",
   "scripts": {

--- a/demo1/tests/happy-path.spec.js
+++ b/demo1/tests/happy-path.spec.js
@@ -118,56 +118,62 @@ test.describe('Happy Path - OAuth Login Flow', () => {
     // Create first browser context and page for OAuth login
     const context1 = await browser.newContext()
     const page1 = await context1.newPage()
-    console.log('📱 Created first browser context for OAuth login')
+    let context2 = null
 
-    // Login via OAuth in first context
-    await loginToApplication(page1)
+    try {
+      console.log('📱 Created first browser context for OAuth login')
 
-    // Capture credentials from profile page
-    const credentials = await captureCredentialsFromProfile(page1)
-    console.log('📋 Credentials captured from first session')
+      // Login via OAuth in first context
+      await loginToApplication(page1)
 
-    // Create second browser context (completely isolated)
-    const context2 = await browser.newContext()
-    const page2 = await context2.newPage()
-    console.log('📱 Created second browser context for direct access')
+      // Capture credentials from profile page
+      const credentials = await captureCredentialsFromProfile(page1)
+      console.log('📋 Credentials captured from first session')
 
-    // Navigate to direct access page in second context
-    await page2.goto('/direct')
-    await expect(page2.getByRole('heading', { name: 'Direct Access' })).toBeVisible()
-    console.log('✅ Second context on Direct Access page')
+      // Create second browser context (completely isolated)
+      context2 = await browser.newContext()
+      const page2 = await context2.newPage()
+      console.log('📱 Created second browser context for direct access')
 
-    // Fill in the captured credentials
-    await page2.getByLabel('Access Token').fill(credentials.token)
-    console.log('✅ Entered captured access token')
+      // Navigate to direct access page in second context
+      await page2.goto('/direct')
+      await expect(page2.getByRole('heading', { name: 'Direct Access' })).toBeVisible()
+      console.log('✅ Second context on Direct Access page')
 
-    await page2.getByLabel('Base URL').fill(credentials.hostname)
-    console.log(`✅ Entered hostname: ${credentials.hostname}`)
+      // Fill in the captured credentials
+      await page2.getByLabel('Access Token').fill(credentials.token)
+      console.log('✅ Entered captured access token')
 
-    await page2.getByLabel('Port').fill(credentials.port.toString())
-    console.log(`✅ Entered port: ${credentials.port}`)
+      await page2.getByLabel('Base URL').fill(credentials.hostname)
+      console.log(`✅ Entered hostname: ${credentials.hostname}`)
 
-    // Click Proceed
-    await page2.getByRole('button', { name: 'Proceed' }).click()
-    console.log('👆 Clicked Proceed')
+      await page2.getByLabel('Port').fill(credentials.port.toString())
+      console.log(`✅ Entered port: ${credentials.port}`)
 
-    // Verify successful login - should redirect to profile
-    await page2.waitForURL('/profile', { timeout: 15000 })
-    console.log('✅ Redirected to profile page')
+      // Click Proceed
+      await page2.getByRole('button', { name: 'Proceed' }).click()
+      console.log('👆 Clicked Proceed')
 
-    // Verify profile content is displayed
-    await expect(page2.locator('h3', { hasText: 'User Profile' })).toBeVisible({ timeout: 15000 })
-    console.log('✅ User Profile heading visible in second context')
+      // Verify successful login - should redirect to profile
+      await page2.waitForURL('/profile', { timeout: 15000 })
+      console.log('✅ Redirected to profile page')
 
-    // Verify credentials section shows the token
-    await expect(page2.locator('h3', { hasText: 'Credentials' })).toBeVisible()
-    console.log('✅ Credentials section visible')
+      // Verify profile content is displayed
+      await expect(page2.locator('h3', { hasText: 'User Profile' })).toBeVisible({ timeout: 15000 })
+      console.log('✅ User Profile heading visible in second context')
 
-    // Clean up - close both contexts
-    await context1.close()
-    await context2.close()
-    console.log('🧹 Closed both browser contexts')
+      // Verify credentials section shows the token
+      await expect(page2.locator('h3', { hasText: 'Credentials' })).toBeVisible()
+      console.log('✅ Credentials section visible')
 
-    console.log('\n✅ Direct access with captured token test completed!\n')
+      console.log('\n✅ Direct access with captured token test completed!\n')
+    } finally {
+      // Clean up - always close contexts even if test fails
+      await context1.close()
+      if (context2) {
+        await context2.close()
+      }
+      console.log('🧹 Closed browser contexts')
+    }
   })
 })

--- a/demo1/tests/happy-path.spec.js
+++ b/demo1/tests/happy-path.spec.js
@@ -147,7 +147,7 @@ test.describe('Happy Path - OAuth Login Flow', () => {
       await page2.getByLabel('Base URL').fill(credentials.hostname)
       console.log(`✅ Entered hostname: ${credentials.hostname}`)
 
-      await page2.getByLabel('Port').fill(credentials.port.toString())
+      await page2.getByLabel('Port').fill(credentials.port)
       console.log(`✅ Entered port: ${credentials.port}`)
 
       // Click Proceed

--- a/demo1/tests/happy-path.spec.js
+++ b/demo1/tests/happy-path.spec.js
@@ -10,7 +10,7 @@
  */
 
 import { test, expect } from '@playwright/test'
-import { loginToApplication, logoutFromApplication, MAX_TEST_TIMEOUT } from './utils.js'
+import { loginToApplication, logoutFromApplication, captureCredentialsFromProfile, MAX_TEST_TIMEOUT } from './utils.js'
 
 test.describe('Happy Path - OAuth Login Flow', () => {
   test('should complete full login and logout flow', async ({ page }) => {
@@ -109,5 +109,65 @@ test.describe('Happy Path - OAuth Login Flow', () => {
     console.log('✅ Back to login page')
 
     console.log('\n✅ Direct access navigation test completed!\n')
+  })
+
+  test('should login via direct access using token from another session', async ({ browser }) => {
+    console.log(`\n▶️ Running Test: ${test.info().title}\n`)
+    test.setTimeout(MAX_TEST_TIMEOUT * 2) // Allow extra time for two login flows
+
+    // Create first browser context and page for OAuth login
+    const context1 = await browser.newContext()
+    const page1 = await context1.newPage()
+    console.log('📱 Created first browser context for OAuth login')
+
+    // Login via OAuth in first context
+    await loginToApplication(page1)
+
+    // Capture credentials from profile page
+    const credentials = await captureCredentialsFromProfile(page1)
+    console.log('📋 Credentials captured from first session')
+
+    // Create second browser context (completely isolated)
+    const context2 = await browser.newContext()
+    const page2 = await context2.newPage()
+    console.log('📱 Created second browser context for direct access')
+
+    // Navigate to direct access page in second context
+    await page2.goto('/direct')
+    await expect(page2.getByRole('heading', { name: 'Direct Access' })).toBeVisible()
+    console.log('✅ Second context on Direct Access page')
+
+    // Fill in the captured credentials
+    await page2.getByLabel('Access Token').fill(credentials.token)
+    console.log('✅ Entered captured access token')
+
+    await page2.getByLabel('Base URL').fill(credentials.hostname)
+    console.log(`✅ Entered hostname: ${credentials.hostname}`)
+
+    await page2.getByLabel('Port').fill(credentials.port.toString())
+    console.log(`✅ Entered port: ${credentials.port}`)
+
+    // Click Proceed
+    await page2.getByRole('button', { name: 'Proceed' }).click()
+    console.log('👆 Clicked Proceed')
+
+    // Verify successful login - should redirect to profile
+    await page2.waitForURL('/profile', { timeout: 15000 })
+    console.log('✅ Redirected to profile page')
+
+    // Verify profile content is displayed
+    await expect(page2.locator('h3', { hasText: 'User Profile' })).toBeVisible({ timeout: 15000 })
+    console.log('✅ User Profile heading visible in second context')
+
+    // Verify credentials section shows the token
+    await expect(page2.locator('h3', { hasText: 'Credentials' })).toBeVisible()
+    console.log('✅ Credentials section visible')
+
+    // Clean up - close both contexts
+    await context1.close()
+    await context2.close()
+    console.log('🧹 Closed both browser contexts')
+
+    console.log('\n✅ Direct access with captured token test completed!\n')
   })
 })

--- a/demo1/tests/utils.js
+++ b/demo1/tests/utils.js
@@ -152,16 +152,13 @@ export async function captureCredentialsFromProfile(page) {
   await showButton.click()
   console.log('👆 Clicked Show & Copy')
 
-  // Wait a moment for the input type to change
-  await page.waitForTimeout(500)
-
-  // Get token value - find the input in the Access Token row
-  const tokenInput = page.locator('input[type="text"]').filter({ has: page.locator('..', { has: page.locator('label:has-text("Access Token")') }) })
-
-  // Alternative: get the input that follows the Access Token label
+  // Wait for the input type to change from password to text
   const tokenRow = page.locator('.flex.items-center').filter({ hasText: 'Access Token' })
+  await tokenRow.locator('input[type="text"]').waitFor({ state: 'visible', timeout: 5000 })
+
+  // Get token value from the Access Token row
   const token = await tokenRow.locator('input').inputValue()
-  console.log(`✅ Captured token: ${token.substring(0, 20)}...`)
+  console.log(`✅ Captured token: ${token.substring(0, 8)}...`)
 
   return { token, hostname, port }
 }


### PR DESCRIPTION
## Summary

Adds a new end-to-end test that verifies the direct access login feature works correctly by using a captured access token from an OAuth session.

### New Test: "should login via direct access using token from another session"

**Test Flow:**
1. Creates first browser context and logs in via OAuth
2. Captures access token, hostname, and port from the profile page
3. Creates second isolated browser context (simulating a different session)
4. Navigates to `/direct` page and enters captured credentials
5. Clicks "Proceed" and verifies successful redirect to `/profile`
6. Verifies profile content is displayed correctly
7. Cleans up both browser contexts

This test ensures that:
- Tokens obtained via OAuth can be reused in different sessions
- The direct access feature correctly authenticates with valid tokens
- The EEN API responds correctly to direct token usage

## Test Results
| Component | Tests | Status |
|-----------|-------|--------|
| Proxy API | 195+ | ✅ Passed |
| Admin | 16 | ✅ Passed |
| Demo1 | 11 | ✅ Passed |

## Versions
- Proxy: v1.1.9
- Admin: v1.0.14
- Demo1: v0.0.21

🤖 Generated with [Claude Code](https://claude.com/claude-code)