### PR TITLE
ci: add separate test workflow for demo1 PRs

### DIFF
--- a/.github/workflows/test-demo1-pr.yml
+++ b/.github/workflows/test-demo1-pr.yml
@@ -1,0 +1,162 @@
+name: Test Demo1 PR (Local Proxy)
+
+on:
+  pull_request:
+    branches:
+      - production
+    paths:
+      - 'demo1/**'
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: |
+            demo1/package-lock.json
+            proxy/package-lock.json
+
+      - name: Debug - Check environment
+        run: |
+          echo "=== Environment Debug ==="
+          echo "GITHUB_EVENT_NAME: $GITHUB_EVENT_NAME"
+          echo "GITHUB_REF: $GITHUB_REF"
+          echo "GITHUB_HEAD_REF: $GITHUB_HEAD_REF"
+          echo "GITHUB_BASE_REF: $GITHUB_BASE_REF"
+          echo ""
+          echo "=== Secrets Check (existence only) ==="
+          if [ -n "${{ secrets.VITE_EEN_CLIENT_ID }}" ]; then echo "✅ VITE_EEN_CLIENT_ID is set"; else echo "❌ VITE_EEN_CLIENT_ID is NOT set"; fi
+          if [ -n "${{ secrets.EEN_CLIENT_SECRET }}" ]; then echo "✅ EEN_CLIENT_SECRET is set"; else echo "❌ EEN_CLIENT_SECRET is NOT set"; fi
+          if [ -n "${{ secrets.TEST_USER }}" ]; then echo "✅ TEST_USER is set"; else echo "❌ TEST_USER is NOT set"; fi
+          if [ -n "${{ secrets.TEST_PASSWORD }}" ]; then echo "✅ TEST_PASSWORD is set"; else echo "❌ TEST_PASSWORD is NOT set"; fi
+
+      - name: Install demo1 dependencies
+        run: npm ci
+        working-directory: demo1
+
+      - name: Install proxy dependencies
+        run: npm ci
+        working-directory: proxy
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium
+        working-directory: demo1
+
+      - name: Create proxy dev vars
+        run: |
+          echo "=== Creating .dev.vars ==="
+          # Quote values to handle special characters like # which would start a comment
+          printf 'CLIENT_ID="%s"\n' "$CLIENT_ID" > .dev.vars
+          printf 'CLIENT_SECRET="%s"\n' "$CLIENT_SECRET" >> .dev.vars
+          printf 'ALLOWED_ORIGINS="%s"\n' "http://127.0.0.1:3333" >> .dev.vars
+          echo "✅ .dev.vars created"
+          echo "=== .dev.vars contents (masked) ==="
+          sed 's/=.*/=***/' .dev.vars
+        working-directory: proxy
+        env:
+          CLIENT_ID: ${{ secrets.VITE_EEN_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.EEN_CLIENT_SECRET }}
+
+      - name: Start local proxy
+        run: |
+          echo "=== Starting wrangler dev ==="
+          npx wrangler dev --port 8787 --local > /tmp/proxy.log 2>&1 &
+          PROXY_PID=$!
+          echo $PROXY_PID > /tmp/proxy.pid
+          echo "Proxy PID: $PROXY_PID"
+
+          echo "=== Waiting for proxy to be ready ==="
+          for i in {1..30}; do
+            if curl -s http://localhost:8787/health > /dev/null 2>&1; then
+              echo "✅ Proxy is ready after $i attempts"
+              curl -s http://localhost:8787/health | jq . || curl -s http://localhost:8787/health
+              break
+            fi
+            echo "⏳ Waiting for proxy... ($i/30)"
+            sleep 2
+          done
+
+          # Final check
+          if ! curl -s http://localhost:8787/health > /dev/null 2>&1; then
+            echo "❌ Proxy failed to start"
+            echo "=== Proxy logs ==="
+            cat /tmp/proxy.log || true
+            exit 1
+          fi
+        working-directory: proxy
+
+      - name: Debug - Verify proxy is running
+        run: |
+          echo "=== Proxy Health Check ==="
+          curl -v http://localhost:8787/health 2>&1 || true
+          echo ""
+          echo "=== Proxy Process ==="
+          ps aux | grep wrangler || true
+          echo ""
+          echo "=== Test OAuth Token Endpoint (expect error - no valid code) ==="
+          curl -v -X POST http://localhost:8787/oauth/token \
+            -H "Content-Type: application/json" \
+            -H "Origin: http://127.0.0.1:3333" \
+            -d '{"code":"test_invalid_code","redirect_uri":"http://127.0.0.1:3333"}' 2>&1 || true
+          echo ""
+          echo "=== Current Proxy Logs ==="
+          cat /tmp/proxy.log || true
+
+      - name: Run tests against local proxy
+        run: |
+          echo "=== Running Playwright tests ==="
+          echo "VITE_PROXY_URL: $VITE_PROXY_URL"
+          echo "VITE_REDIRECT_URI: $VITE_REDIRECT_URI"
+          if [ -n "$VITE_EEN_CLIENT_ID" ]; then echo "✅ VITE_EEN_CLIENT_ID is set"; else echo "❌ VITE_EEN_CLIENT_ID is NOT set"; fi
+          echo ""
+          npx playwright test -x
+        working-directory: demo1
+        env:
+          VITE_PROXY_URL: 'http://localhost:8787'
+          VITE_EEN_CLIENT_ID: ${{ secrets.VITE_EEN_CLIENT_ID }}
+          VITE_REDIRECT_URI: 'http://127.0.0.1:3333'
+          TEST_USER: ${{ secrets.TEST_USER }}
+          TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+
+      - name: Show proxy logs
+        if: always()
+        run: |
+          echo "=== Proxy Logs ==="
+          cat /tmp/proxy.log || echo "No proxy logs found"
+
+      - name: Stop local proxy
+        if: always()
+        run: |
+          echo "=== Stopping proxy ==="
+          if [ -f /tmp/proxy.pid ]; then
+            PID=$(cat /tmp/proxy.pid)
+            echo "Killing proxy PID: $PID"
+            kill $PID 2>/dev/null || true
+            # Also kill any wrangler processes
+            pkill -f wrangler || true
+          fi
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report-demo1-pr
+          path: demo1/playwright-report/
+          retention-days: 7
+
+      - name: Upload test screenshots
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: test-screenshots-demo1-pr
+          path: demo1/test-results/
+          retention-days: 7


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow specifically for testing demo1 when PRs to production include demo1 changes.

### Changes
- Added `.github/workflows/test-demo1-pr.yml` that mirrors `test-admin-pr.yml`
- Triggers on PRs to production with `demo1/**` or `.github/workflows/**` changes
- Runs demo1 Playwright tests against a local proxy

### Why
Previously, the "test" required check on production PRs would never run for demo1-only changes because `test-admin-pr.yml` only triggers on `admin/**` and `proxy/**` paths. This caused PRs with only demo1 changes to be blocked.

### Versions
| Component | Version |
|-----------|---------|
| Proxy     | 1.1.9   |
| Admin     | 1.0.14  |
| Demo1     | 0.0.23  |

🤖 Generated with [Claude Code](https://claude.com/claude-code)