### PR TITLE
feat: add pre-commit hook to check proxy deployment status

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 # Pre-commit hook to increment version in subfolders with staged changes
+# and check if proxy deployment is needed
+
+PROXY_URL="${PROXY_URL:-https://een-oauth-proxy.klaushofrichter.workers.dev}"
 
 increment_version() {
     local folder=$1
@@ -23,8 +26,10 @@ increment_version() {
 }
 
 # Check if proxy folder has staged changes
+proxy_changed=false
 if git diff --cached --name-only | grep -q "^proxy/"; then
     increment_version "proxy"
+    proxy_changed=true
 fi
 
 # Check if demo1 folder has staged changes
@@ -35,6 +40,39 @@ fi
 # Check if admin folder has staged changes
 if git diff --cached --name-only | grep -q "^admin/"; then
     increment_version "admin"
+fi
+
+# Check proxy deployment status if proxy was changed
+if [ "$proxy_changed" = true ]; then
+    echo ""
+    echo "========================================"
+    echo "  Proxy Deployment Check"
+    echo "========================================"
+
+    # Get local version from package.json
+    local_version=$(node -p "require('./proxy/package.json').version" 2>/dev/null)
+
+    # Try to get deployed version from health endpoint
+    deployed_version=$(curl -s --connect-timeout 5 "$PROXY_URL/health" 2>/dev/null | node -p "try { JSON.parse(require('fs').readFileSync('/dev/stdin', 'utf8')).version.split(' - ')[1] } catch(e) { '' }" 2>/dev/null)
+
+    if [ -n "$deployed_version" ]; then
+        echo "  Local version:    v$local_version"
+        echo "  Deployed version: v$deployed_version"
+
+        if [ "$local_version" != "$deployed_version" ]; then
+            echo ""
+            echo "  ⚠️  DEPLOYMENT NEEDED"
+            echo "  Run 'cd proxy && npm run deploy' after merging to production"
+        else
+            echo ""
+            echo "  ✓ Versions match (will differ after this commit)"
+        fi
+    else
+        echo "  Local version: v$local_version"
+        echo "  ⚠️  Could not fetch deployed version from $PROXY_URL"
+    fi
+    echo "========================================"
+    echo ""
 fi
 
 exit 0

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^16.4.7",

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -3,6 +3,7 @@
  *
  * This worker handles OAuth authentication with Eagle Eye Networks (EEN) services.
  * It keeps CLIENT_ID and CLIENT_SECRET secure on the server side.
+ * Pre-commit hook will remind to deploy when proxy changes are committed.
  *
  * Endpoints:
  *   POST /proxy/getAccessToken     - Exchange authorization code for tokens


### PR DESCRIPTION
## Summary

- Add pre-commit hook that checks if proxy deployment is needed when proxy files are committed
- Fetches deployed version from proxy health endpoint and compares to local version
- Displays clear deployment reminder with instructions when versions differ

## Changes

- `.husky/pre-commit`: Enhanced to check proxy deployment status after version bump
- `proxy/src/index.js`: Added comment documenting the deployment reminder feature

## Test Results

| Component | Tests | Status |
|-----------|-------|--------|
| Proxy | 231 | ✅ Passed |
| Admin | 16 | ✅ Passed |
| Demo1 | 11 | ✅ Passed |

## Versions

- proxy: v1.2.7
- admin: v1.0.21
- demo1: v0.0.27

## Example Output

When committing proxy changes, the hook displays:
```
========================================
  Proxy Deployment Check
========================================
  Local version:    v1.2.7
  Deployed version: v1.2.6

  ⚠️  DEPLOYMENT NEEDED
  Run 'cd proxy && npm run deploy' after merging to production
========================================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)