### PR TITLE
fix: improve pre-commit hook based on code review feedback

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -10,18 +10,24 @@
 PROXY_URL="${PROXY_URL:-https://een-oauth-proxy.klaushofrichter.workers.dev}"
 
 increment_version() {
-    folder=$1
-    package_json="$folder/package.json"
-    package_lock="$folder/package-lock.json"
+    local folder="$1"
+    local package_json="$folder/package.json"
+    local package_lock="$folder/package-lock.json"
 
     if [ -f "$package_json" ]; then
         echo "Incrementing version in $folder..."
-        cd "$folder"
-        npm version patch --no-git-tag-version
-        if [ -f "package-lock.json" ]; then
-            npm install --package-lock-only
+        # Use subshell to avoid directory issues on error
+        (
+            cd "$folder" || exit 1
+            npm version patch --no-git-tag-version || exit 1
+            if [ -f "package-lock.json" ]; then
+                npm install --package-lock-only || exit 1
+            fi
+        )
+        if [ $? -ne 0 ]; then
+            echo "Error: Failed to increment version in $folder"
+            return 1
         fi
-        cd - > /dev/null
         git add "$package_json"
         if [ -f "$package_lock" ]; then
             git add "$package_lock"
@@ -38,18 +44,24 @@ fi
 # Check if proxy folder has staged changes
 proxy_changed=false
 if git diff --cached --name-only | grep -q "^proxy/"; then
-    increment_version "proxy"
+    if ! increment_version "proxy"; then
+        exit 1
+    fi
     proxy_changed=true
 fi
 
 # Check if demo1 folder has staged changes
 if git diff --cached --name-only | grep -q "^demo1/"; then
-    increment_version "demo1"
+    if ! increment_version "demo1"; then
+        exit 1
+    fi
 fi
 
 # Check if admin folder has staged changes
 if git diff --cached --name-only | grep -q "^admin/"; then
-    increment_version "admin"
+    if ! increment_version "admin"; then
+        exit 1
+    fi
 fi
 
 # Check proxy deployment status if proxy was changed
@@ -62,10 +74,22 @@ if [ "$proxy_changed" = true ] && [ "$SKIP_DEPLOYMENT_CHECK" != "1" ]; then
     # Get the new local version (after increment)
     local_version=$(node -p "require('./proxy/package.json').version" 2>/dev/null)
 
-    # Try to get deployed version from health endpoint (2s timeout for speed)
-    health_response=$(curl -s --connect-timeout 2 --max-time 3 "$PROXY_URL/health" 2>/dev/null)
+    # Try to get deployed version from health endpoint
+    # --max-redirs 0 prevents following redirects for security
+    health_response=$(curl -s --max-redirs 0 --connect-timeout 2 --max-time 3 "$PROXY_URL/health" 2>/dev/null)
+
     if [ -n "$health_response" ]; then
-        deployed_version=$(echo "$health_response" | node -p "try { JSON.parse(require('fs').readFileSync(0, 'utf8')).version.split(' - ')[1] } catch(e) { '' }" 2>/dev/null)
+        # Parse version using node with proper stdin handling
+        deployed_version=$(echo "$health_response" | node -e "
+            let data = '';
+            process.stdin.on('data', chunk => data += chunk);
+            process.stdin.on('end', () => {
+                try {
+                    const version = JSON.parse(data).version.split(' - ')[1];
+                    if (version) console.log(version);
+                } catch(e) {}
+            });
+        " 2>/dev/null)
     fi
 
     if [ -n "$deployed_version" ]; then

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,14 +1,18 @@
-#!/bin/sh
+#!/bin/bash
 
 # Pre-commit hook to increment version in subfolders with staged changes
 # and check if proxy deployment is needed
+#
+# Environment variables:
+#   PROXY_URL              - Override proxy URL (default: production)
+#   SKIP_DEPLOYMENT_CHECK  - Set to 1 to skip deployment check
 
 PROXY_URL="${PROXY_URL:-https://een-oauth-proxy.klaushofrichter.workers.dev}"
 
 increment_version() {
-    local folder=$1
-    local package_json="$folder/package.json"
-    local package_lock="$folder/package-lock.json"
+    folder=$1
+    package_json="$folder/package.json"
+    package_lock="$folder/package-lock.json"
 
     if [ -f "$package_json" ]; then
         echo "Incrementing version in $folder..."
@@ -24,6 +28,12 @@ increment_version() {
         fi
     fi
 }
+
+# Capture proxy version BEFORE incrementing (for accurate comparison)
+proxy_version_before=""
+if git diff --cached --name-only | grep -q "^proxy/"; then
+    proxy_version_before=$(node -p "require('./proxy/package.json').version" 2>/dev/null)
+fi
 
 # Check if proxy folder has staged changes
 proxy_changed=false
@@ -43,33 +53,39 @@ if git diff --cached --name-only | grep -q "^admin/"; then
 fi
 
 # Check proxy deployment status if proxy was changed
-if [ "$proxy_changed" = true ]; then
+if [ "$proxy_changed" = true ] && [ "$SKIP_DEPLOYMENT_CHECK" != "1" ]; then
     echo ""
     echo "========================================"
     echo "  Proxy Deployment Check"
     echo "========================================"
 
-    # Get local version from package.json
+    # Get the new local version (after increment)
     local_version=$(node -p "require('./proxy/package.json').version" 2>/dev/null)
 
-    # Try to get deployed version from health endpoint
-    deployed_version=$(curl -s --connect-timeout 5 "$PROXY_URL/health" 2>/dev/null | node -p "try { JSON.parse(require('fs').readFileSync('/dev/stdin', 'utf8')).version.split(' - ')[1] } catch(e) { '' }" 2>/dev/null)
+    # Try to get deployed version from health endpoint (2s timeout for speed)
+    health_response=$(curl -s --connect-timeout 2 --max-time 3 "$PROXY_URL/health" 2>/dev/null)
+    if [ -n "$health_response" ]; then
+        deployed_version=$(echo "$health_response" | node -p "try { JSON.parse(require('fs').readFileSync(0, 'utf8')).version.split(' - ')[1] } catch(e) { '' }" 2>/dev/null)
+    fi
 
     if [ -n "$deployed_version" ]; then
-        echo "  Local version:    v$local_version"
-        echo "  Deployed version: v$deployed_version"
+        echo "  Local version (after bump): v$local_version"
+        echo "  Deployed version:           v$deployed_version"
 
-        if [ "$local_version" != "$deployed_version" ]; then
+        if [ "$proxy_version_before" = "$deployed_version" ]; then
             echo ""
-            echo "  ⚠️  DEPLOYMENT NEEDED"
+            echo "  ⚠️  DEPLOYMENT NEEDED after merge"
             echo "  Run 'cd proxy && npm run deploy' after merging to production"
         else
             echo ""
-            echo "  ✓ Versions match (will differ after this commit)"
+            echo "  ⚠️  DEPLOYMENT ALREADY PENDING"
+            echo "  Deployed version differs from pre-commit version (v$proxy_version_before)"
+            echo "  Run 'cd proxy && npm run deploy' after merging to production"
         fi
     else
         echo "  Local version: v$local_version"
-        echo "  ⚠️  Could not fetch deployed version from $PROXY_URL"
+        echo "  ⚠️  Could not fetch deployed version (network timeout or error)"
+        echo "  Set SKIP_DEPLOYMENT_CHECK=1 to skip this check"
     fi
     echo "========================================"
     echo ""

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^16.4.7",

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -3,7 +3,6 @@
  *
  * This worker handles OAuth authentication with Eagle Eye Networks (EEN) services.
  * It keeps CLIENT_ID and CLIENT_SECRET secure on the server side.
- * Pre-commit hook will remind to deploy when proxy changes are committed.
  *
  * Endpoints:
  *   POST /proxy/getAccessToken     - Exchange authorization code for tokens


### PR DESCRIPTION
## Summary

Addresses code review feedback from PR #70 to improve the pre-commit deployment check hook.

## Changes

### Fixed Issues
- **Version comparison logic**: Capture version BEFORE incrementing for accurate comparison
- **Performance**: Reduced network timeout from 5s to 2s
- **Skip option**: Added `SKIP_DEPLOYMENT_CHECK=1` env var to bypass network check
- **Shell portability**: Changed shebang to `#!/bin/bash` (removes `local` keyword issue)
- **Version parsing**: Simplified stdin reading with `readFileSync(0, 'utf8')`
- **Messages**: Distinguished "deployment needed" vs "already pending" scenarios
- **Code cleanup**: Removed meta-comment from `proxy/src/index.js`

### Example Output (improved)
```
========================================
  Proxy Deployment Check
========================================
  Local version (after bump): v1.2.8
  Deployed version:           v1.2.6

  ⚠️  DEPLOYMENT ALREADY PENDING
  Deployed version differs from pre-commit version (v1.2.7)
  Run 'cd proxy && npm run deploy' after merging to production
========================================
```

## Test Results

| Component | Tests | Status |
|-----------|-------|--------|
| Proxy | 231 | ✅ Passed |
| Admin | 16 | ✅ Passed |
| Demo1 | 11 | ✅ Passed |

## Versions
- proxy: v1.2.8
- admin: v1.0.21  
- demo1: v0.0.27

🤖 Generated with [Claude Code](https://claude.com/claude-code)