### PR TITLE
Fix CSP plugin for Vite mode-based environment loading

### DIFF
--- a/.github/workflows/check-proxy-version.yml
+++ b/.github/workflows/check-proxy-version.yml
@@ -27,9 +27,13 @@ jobs:
       - name: Get Deployed Proxy Version
         id: deployed_version
         env:
-          # Use the repository variable if set, otherwise fallback to the known production URL
-          PROXY_URL: ${{ vars.VITE_PROXY_URL || 'https://een-oauth-proxy.klaushofrichter.workers.dev' }}
+          # VITE_PROXY_URL must be set as a repository variable
+          PROXY_URL: ${{ vars.VITE_PROXY_URL }}
         run: |
+          if [ -z "$PROXY_URL" ]; then
+            echo "::error::VITE_PROXY_URL repository variable is not set. Please configure it in Settings > Secrets and variables > Actions > Variables."
+            exit 1
+          fi
           echo "Checking deployed version at $PROXY_URL/health..."
           
           # Fetch health endpoint with timeout

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ web_modules/
 .env
 .env.*
 !.env.example
+!.env.prod.example
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -56,4 +56,18 @@ if git diff --cached --name-only | grep -q "^admin/"; then
     fi
 fi
 
+# Check if proxy folder has staged changes - if so, check deployment status
+if git diff --cached --name-only | grep -q "^proxy/"; then
+    if [ "${SKIP_DEPLOYMENT_CHECK:-0}" != "1" ]; then
+        echo ""
+        echo "Checking proxy deployment status..."
+        if ! bash scripts/check-deployment.sh; then
+            echo ""
+            echo "⚠️  Warning: Proxy version check failed. Deployment may be needed."
+            echo "   Set SKIP_DEPLOYMENT_CHECK=1 to skip this check."
+            # Don't fail the commit, just warn
+        fi
+    fi
+fi
+
 exit 0

--- a/README.md
+++ b/README.md
@@ -10,6 +10,56 @@ This repository is provided as is without any warranty, functionality guarantee 
 This repository uses EENs services, but it is not associated to EEN. 
 
 
+## Features
+
+### Proxy Features
+
+The OAuth proxy provides secure token management for Eagle Eye Networks authentication:
+
+- **OAuth Token Exchange** - Securely exchanges authorization codes for access tokens, keeping CLIENT_SECRET server-side
+- **Token Refresh** - Automatic refresh token management with server-side storage in Cloudflare KV
+- **Token Revocation** - Clean logout with EEN token revocation and session cleanup
+- **Session Management** - Server-side sessions with configurable TTL and automatic expiration
+- **Health Monitoring** - Public health endpoint for uptime monitoring (supports HEAD requests)
+- **Multi-Region Support** - Automatically handles EEN regional API endpoints (httpsBaseUrl)
+
+### Security Features
+
+The proxy implements multiple layers of security:
+
+- **Rate Limiting** - Configurable per-endpoint rate limits to prevent abuse:
+  - `/health`: 60 requests/minute (default)
+  - `/proxy/*`: 30 requests/minute (default)
+  - `/admin/*`: 60 requests/minute (default)
+  - Unknown clients (no IP identification): 5 requests/minute
+  - Configurable via environment variables (`RATE_LIMIT_*`)
+- **CORS Protection** - Strict origin validation with configurable allowlist
+- **CSRF Protection** - Origin header required for state-changing requests (POST/DELETE)
+- **Secure Cookies** - HttpOnly, Secure, SameSite=None session cookies
+- **Header-Based Auth** - Supports `Authorization: Bearer <sessionId>` for mobile/cross-site compatibility (ITP bypass). *Note: This requires storing the session ID in client storage (localStorage), which has different security trade-offs compared to HttpOnly cookies.*
+- **Input Validation** - Length limits and format validation on all inputs
+- **Session ID Security** - Cryptographically random UUIDs with format validation
+- **No Secret Exposure** - CLIENT_SECRET and refresh tokens never sent to frontend
+- **Security Headers** - X-Content-Type-Options, X-Frame-Options, CSP, HSTS (production)
+- **Admin Access Control** - Email-based allowlist for administrative functions
+- **Open Redirect Prevention** - Redirect URI validation against allowed origins
+- **Timing Attack Prevention** - Constant-time comparison for sensitive operations
+
+### Admin App Features
+
+The admin application provides monitoring and management capabilities:
+
+- **Dashboard Overview** - Real-time proxy health status and version information
+- **Session Monitoring** - View count of active user sessions
+- **Rate Limit Statistics** - Monitor rate limiting activity across endpoints
+- **Session Management** - Remove other users' sessions while preserving your own
+- **Emergency Revocation** - Revoke all tokens system-wide (logs out all users)
+- **Activity Log** - Real-time log of admin actions with timestamps
+- **Dark Mode** - Toggle between light and dark themes (persisted)
+- **Resizable Panels** - Adjustable dashboard layout (persisted)
+- **Auto-Refresh** - Automatic health check updates with countdown timer
+- **Non-Admin Rejection** - Clear error messages for users not in admin list
+
 ## Project Structure
 
 ```
@@ -621,14 +671,14 @@ Values outside the min/max range are automatically clamped. Adjust this value ba
 
 | Method | Endpoint | Auth Required | Description |
 |--------|----------|---------------|-------------|
-| POST | `/proxy/getAccessToken` | No (uses OAuth code) | Exchange authorization code for access token. Returns access token, stores refresh token server-side. |
-| POST | `/proxy/refreshAccessToken` | Session cookie | Refresh access token using stored refresh token. |
-| POST | `/proxy/revoke` | Session cookie | Revoke tokens at EEN and clear server-side session. |
+| POST | `/proxy/getAccessToken` | No (uses OAuth code) | Exchange authorization code for access token. Returns access token and `sessionId` (in body), stores refresh token server-side. |
+| POST | `/proxy/refreshAccessToken` | Session cookie OR Header | Refresh access token using stored refresh token. |
+| POST | `/proxy/revoke` | Session cookie OR Header | Revoke tokens at EEN and clear server-side session. |
 
 ### Admin Endpoints (Admin User Required)
 
 These endpoints require:
-1. A valid session cookie (`sessionId`)
+1. A valid session (`sessionId`) provided via `Cookie` OR `Authorization: Bearer <sessionId>` header
 2. The session's `userEmail` must be in the `ADMIN_EMAILS` environment variable
 
 | Method | Endpoint | Description |
@@ -653,6 +703,7 @@ For example, if you modify files in `proxy/`, the `proxy/package.json` version w
 - **CLIENT_SECRET** is never exposed to the frontend
 - **Refresh tokens** are stored server-side only in Cloudflare KV
 - **Session cookies** are HttpOnly, Secure, and SameSite=None
+- **Header-Based Auth** is supported for mobile clients where third-party cookies are blocked (ITP). This mechanism uses `localStorage` on the client, which is accessible to JavaScript. While necessary for functionality in some environments, it relies on XSS protection (CSP, input sanitization) rather than the HttpOnly flag for security.
 - **CORS validation** on all proxy requests
 - **Admin endpoints** require email verification against allowlist
 - **Automatic token expiration** via KV TTL

--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ ENVIRONMENT=development
 
 For production deployment, also create `proxy/.env` with the same values (used by the deploy script to set Cloudflare secrets).
 
+**Mode-Based Environment Loading:**
+
+Both demo1 and admin apps support mode-based environment loading:
+- `npm run dev` - Uses local proxy (localhost:8787), loads `.env`
+- `npm run dev:prod` - Uses Cloudflare proxy, loads `.env` AND `.env.prod`
+
+The `.env.prod` file should contain `VITE_PROXY_URL` pointing to your deployed Cloudflare Worker.
+
 **Demo App (`./demo1`):**
 ```bash
 cd demo1
@@ -204,14 +212,6 @@ Edit `admin/.env.prod` (optional, for `npm run dev:prod`):
 ```env
 VITE_PROXY_URL=https://your-proxy.your-subdomain.workers.dev
 ```
-
-**Mode-Based Environment Loading:**
-
-Both demo1 and admin apps support mode-based environment loading:
-- `npm run dev` - Uses local proxy (localhost:8787), loads `.env`
-- `npm run dev:prod` - Uses Cloudflare proxy, loads `.env` AND `.env.prod`
-
-The `.env.prod` file should contain `VITE_PROXY_URL` pointing to your deployed Cloudflare Worker.
 
 ### Step 3: Create Cloudflare KV Namespace
 

--- a/README.md
+++ b/README.md
@@ -9,64 +9,6 @@ See the [Eagleeye Networks Developer Portal](https://developer.eagleeyenetworks.
 This repository is provided as is without any warranty, functionality guarantee or assurance of availability. 
 This repository uses EENs services, but it is not associated to EEN. 
 
-<!-- Version badges - replace 'your-username' with your GitHub username to enable -->
-<!-- ![Proxy Dev Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fyour-username%2Feen-oauth-proxy%2Frefs%2Fheads%2Fdevelop%2Fproxy%2Fpackage.json&query=version&label=proxy-develop&color=%2333ca55) -->
-<!-- ![Proxy Prod Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fyour-username%2Feen-oauth-proxy%2Frefs%2Fheads%2Fproduction%2Fproxy%2Fpackage.json&query=version&label=proxy-production&color=%2333ca55) -->
-<!-- ![Admin Dev Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fyour-username%2Feen-oauth-proxy%2Frefs%2Fheads%2Fdevelop%2Fadmin%2Fpackage.json&query=version&label=admin-develop&color=%2333ca55) -->
-<!-- ![Admin Prod Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fyour-username%2Feen-oauth-proxy%2Frefs%2Fheads%2Fproduction%2Fadmin%2Fpackage.json&query=version&label=admin-production&color=%2333ca55) -->
-<!-- ![Demo1 Dev Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fyour-username%2Feen-oauth-proxy%2Frefs%2Fheads%2Fdevelop%2Fdemo1%2Fpackage.json&query=version&label=demo1-develop&color=%2333ca55) -->
-<!-- ![Demo1 Prod Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fyour-username%2Feen-oauth-proxy%2Frefs%2Fheads%2Fproduction%2Fdemo1%2Fpackage.json&query=version&label=demo1-production&color=%2333ca55) -->
-
-
-## Features
-
-### Proxy Features
-
-The OAuth proxy provides secure token management for Eagle Eye Networks authentication:
-
-- **OAuth Token Exchange** - Securely exchanges authorization codes for access tokens, keeping CLIENT_SECRET server-side
-- **Token Refresh** - Automatic refresh token management with server-side storage in Cloudflare KV
-- **Token Revocation** - Clean logout with EEN token revocation and session cleanup
-- **Session Management** - Server-side sessions with configurable TTL and automatic expiration
-- **Health Monitoring** - Public health endpoint for uptime monitoring (supports HEAD requests)
-- **Multi-Region Support** - Automatically handles EEN regional API endpoints (httpsBaseUrl)
-
-### Security Features
-
-The proxy implements multiple layers of security:
-
-- **Rate Limiting** - Configurable per-endpoint rate limits to prevent abuse:
-  - `/health`: 60 requests/minute (default)
-  - `/proxy/*`: 30 requests/minute (default)
-  - `/admin/*`: 60 requests/minute (default)
-  - Unknown clients (no IP identification): 5 requests/minute
-  - Configurable via environment variables (`RATE_LIMIT_*`)
-- **CORS Protection** - Strict origin validation with configurable allowlist
-- **CSRF Protection** - Origin header required for state-changing requests (POST/DELETE)
-- **Secure Cookies** - HttpOnly, Secure, SameSite=None session cookies
-- **Header-Based Auth** - Supports `Authorization: Bearer <sessionId>` for mobile/cross-site compatibility (ITP bypass). *Note: This requires storing the session ID in client storage (localStorage), which has different security trade-offs compared to HttpOnly cookies.*
-- **Input Validation** - Length limits and format validation on all inputs
-- **Session ID Security** - Cryptographically random UUIDs with format validation
-- **No Secret Exposure** - CLIENT_SECRET and refresh tokens never sent to frontend
-- **Security Headers** - X-Content-Type-Options, X-Frame-Options, CSP, HSTS (production)
-- **Admin Access Control** - Email-based allowlist for administrative functions
-- **Open Redirect Prevention** - Redirect URI validation against allowed origins
-- **Timing Attack Prevention** - Constant-time comparison for sensitive operations
-
-### Admin App Features
-
-The admin application provides monitoring and management capabilities:
-
-- **Dashboard Overview** - Real-time proxy health status and version information
-- **Session Monitoring** - View count of active user sessions
-- **Rate Limit Statistics** - Monitor rate limiting activity across endpoints
-- **Session Management** - Remove other users' sessions while preserving your own
-- **Emergency Revocation** - Revoke all tokens system-wide (logs out all users)
-- **Activity Log** - Real-time log of admin actions with timestamps
-- **Dark Mode** - Toggle between light and dark themes (persisted)
-- **Resizable Panels** - Adjustable dashboard layout (persisted)
-- **Auto-Refresh** - Automatic health check updates with countdown timer
-- **Non-Admin Rejection** - Clear error messages for users not in admin list
 
 ## Project Structure
 
@@ -175,33 +117,51 @@ ENVIRONMENT=development
 
 For production deployment, also create `proxy/.env` with the same values (used by the deploy script to set Cloudflare secrets).
 
-**Demo App (`./demo1/.env`):**
+**Demo App (`./demo1`):**
 ```bash
 cd demo1
 cp .env.example .env
+cp .env.prod.example .env.prod  # Optional: for testing with Cloudflare proxy
 ```
 
 Edit `demo1/.env`:
 ```env
-VITE_PROXY_URL=http://localhost:8787
 VITE_EEN_CLIENT_ID=your-een-client-id
-VITE_EEN_AUTH_URL=https://auth.eagleeyenetworks.com/oauth2/authorize
-VITE_REDIRECT_URI=http://127.0.0.1:3333
+TEST_USER=your-test-email@example.com
+TEST_PASSWORD=your-test-password
 ```
 
-**Admin App (`./admin/.env`):**
+Edit `demo1/.env.prod` (optional, for `npm run dev:prod`):
+```env
+VITE_PROXY_URL=https://your-proxy.your-subdomain.workers.dev
+```
+
+**Admin App (`./admin`):**
 ```bash
 cd admin
 cp .env.example .env
+cp .env.prod.example .env.prod  # Optional: for testing with Cloudflare proxy
 ```
 
 Edit `admin/.env`:
 ```env
-VITE_PROXY_URL=http://localhost:8787
 VITE_EEN_CLIENT_ID=your-een-client-id
-VITE_EEN_AUTH_URL=https://auth.eagleeyenetworks.com/oauth2/authorize
-VITE_REDIRECT_URI=http://127.0.0.1:3333
+ADMIN_TEST_USER=your-admin-email@example.com
+ADMIN_TEST_PASSWORD=your-admin-password
 ```
+
+Edit `admin/.env.prod` (optional, for `npm run dev:prod`):
+```env
+VITE_PROXY_URL=https://your-proxy.your-subdomain.workers.dev
+```
+
+**Mode-Based Environment Loading:**
+
+Both demo1 and admin apps support mode-based environment loading:
+- `npm run dev` - Uses local proxy (localhost:8787), loads `.env`
+- `npm run dev:prod` - Uses Cloudflare proxy, loads `.env` AND `.env.prod`
+
+The `.env.prod` file should contain `VITE_PROXY_URL` pointing to your deployed Cloudflare Worker.
 
 ### Step 3: Create Cloudflare KV Namespace
 
@@ -261,33 +221,6 @@ To switch between apps locally:
 cd demo1 && npm run stop   # Stop current app on port 3333
 cd admin && npm run dev    # Start the other app
 ```
-
-### Running Against Production Proxy
-
-You can run the demo or admin app locally while connecting to your production Cloudflare proxy. This is useful for testing production configurations without deploying the frontend.
-
-**Prerequisites:**
-1. Your production proxy must have `http://127.0.0.1:3333` in `ALLOWED_ORIGINS`
-2. Unix-like environment (macOS, Linux, or WSL/Git Bash on Windows)
-3. Export `VITE_PROD_PROXY_URL` in your shell
-
-**Setup and run:**
-```bash
-# Export the production proxy URL (add to your ~/.bashrc or ~/.zshrc for persistence)
-export VITE_PROD_PROXY_URL=https://your-proxy.your-subdomain.workers.dev
-
-# Demo app against production proxy
-cd demo1
-npm run dev:prod
-
-# Admin app against production proxy
-cd admin
-npm run dev:prod
-```
-
-> **Note:** The `dev:prod` script uses shell variable expansion (`$VITE_PROD_PROXY_URL`), which requires the variable to be exported in your shell environment. Simply adding it to `.env` is not sufficient - you must use `export` or source it from a shell profile.
-
-> **Security Note:** Adding `http://127.0.0.1:3333` to production `ALLOWED_ORIGINS` is safe because `127.0.0.1` only resolves to the local machine and browsers cannot spoof the `Origin` header.
 
 ### Step 5: Run Tests
 
@@ -351,9 +284,11 @@ npx playwright test --debug # Run in debug mode
 
 The admin tests require environment variables in `admin/.env`:
 ```env
-TEST_USER=your-test-email@example.com
-TEST_PASSWORD=your-test-password
-VITE_PROXY_URL=http://localhost:8787
+VITE_EEN_CLIENT_ID=your-een-client-id
+ADMIN_TEST_USER=your-admin-email@example.com
+ADMIN_TEST_PASSWORD=your-admin-password
+TEST_USER=your-non-admin-email@example.com  # Optional: for rejection tests
+TEST_PASSWORD=your-non-admin-password
 ```
 
 **Important:** Destructive tests (remove sessions, revoke all) only run against local proxy (`localhost` or `127.0.0.1`) to protect production data.
@@ -379,9 +314,9 @@ npm run test:ui             # Run with Playwright UI
 
 The demo tests require environment variables in `demo1/.env`:
 ```env
+VITE_EEN_CLIENT_ID=your-een-client-id
 TEST_USER=your-test-email@example.com
 TEST_PASSWORD=your-test-password
-VITE_PROXY_URL=http://localhost:8787
 ```
 
 ### Running All Tests
@@ -686,14 +621,14 @@ Values outside the min/max range are automatically clamped. Adjust this value ba
 
 | Method | Endpoint | Auth Required | Description |
 |--------|----------|---------------|-------------|
-| POST | `/proxy/getAccessToken` | No (uses OAuth code) | Exchange authorization code for access token. Returns access token and `sessionId` (in body), stores refresh token server-side. |
-| POST | `/proxy/refreshAccessToken` | Session cookie OR Header | Refresh access token using stored refresh token. |
-| POST | `/proxy/revoke` | Session cookie OR Header | Revoke tokens at EEN and clear server-side session. |
+| POST | `/proxy/getAccessToken` | No (uses OAuth code) | Exchange authorization code for access token. Returns access token, stores refresh token server-side. |
+| POST | `/proxy/refreshAccessToken` | Session cookie | Refresh access token using stored refresh token. |
+| POST | `/proxy/revoke` | Session cookie | Revoke tokens at EEN and clear server-side session. |
 
 ### Admin Endpoints (Admin User Required)
 
 These endpoints require:
-1. A valid session (`sessionId`) provided via `Cookie` OR `Authorization: Bearer <sessionId>` header
+1. A valid session cookie (`sessionId`)
 2. The session's `userEmail` must be in the `ADMIN_EMAILS` environment variable
 
 | Method | Endpoint | Description |
@@ -718,7 +653,6 @@ For example, if you modify files in `proxy/`, the `proxy/package.json` version w
 - **CLIENT_SECRET** is never exposed to the frontend
 - **Refresh tokens** are stored server-side only in Cloudflare KV
 - **Session cookies** are HttpOnly, Secure, and SameSite=None
-- **Header-Based Auth** is supported for mobile clients where third-party cookies are blocked (ITP). This mechanism uses `localStorage` on the client, which is accessible to JavaScript. While necessary for functionality in some environments, it relies on XSS protection (CSP, input sanitization) rather than the HttpOnly flag for security.
 - **CORS validation** on all proxy requests
 - **Admin endpoints** require email verification against allowlist
 - **Automatic token expiration** via KV TTL

--- a/admin/.env.example
+++ b/admin/.env.example
@@ -1,5 +1,13 @@
 # Admin App Environment Variables
 # Copy this file to .env and fill in your values
+#
+# MODE-BASED LOADING:
+# - .env is loaded for all modes (npm run dev, npm run dev:prod)
+# - .env.prod is loaded ONLY for prod mode (npm run dev:prod)
+# - .env.local and .env.prod.local are gitignored for secrets
+#
+# For local development with local proxy: just create .env
+# For testing with Cloudflare proxy: also create .env.prod (see .env.prod.example)
 
 # EEN OAuth Client ID (required for login)
 VITE_EEN_CLIENT_ID=your-een-client-id

--- a/admin/.env.example
+++ b/admin/.env.example
@@ -1,31 +1,17 @@
-# EEN OAuth Admin - Environment Variables
+# Admin App Environment Variables
 # Copy this file to .env and fill in your values
 
-# Proxy URL for local development (used by npm run dev)
-VITE_PROXY_URL=http://localhost:8787
-
-# Production proxy URL (used by npm run dev:prod)
-# Set this to your deployed Cloudflare Worker URL
-VITE_PROD_PROXY_URL=https://your-proxy.your-subdomain.workers.dev
-
-# EEN OAuth settings
+# EEN OAuth Client ID (required for login)
 VITE_EEN_CLIENT_ID=your-een-client-id
-VITE_EEN_AUTH_URL=https://auth.eagleeyenetworks.com/oauth2/authorize
 
-# Redirect URI (must match your OAuth app configuration)
-# Local development:
-VITE_REDIRECT_URI=http://127.0.0.1:3333
+# Admin test credentials for Playwright tests (must be an admin user)
+ADMIN_TEST_USER=your-admin-email@example.com
+ADMIN_TEST_PASSWORD=your-admin-password
 
-# Production (must exactly match your EEN OAuth app configuration):
-# VITE_REDIRECT_URI=https://your-username.github.io/een-oauth-proxy
+# Non-admin test credentials (optional, for rejection tests)
+TEST_USER=your-non-admin-email@example.com
+TEST_PASSWORD=your-non-admin-password
 
-# GitHub repository URL (for version link in UI)
+# GitHub repository info (optional, for version links)
 VITE_GITHUB_REPO=https://github.com/your-username/een-oauth-proxy
-
-# Test credentials for admin user (must be in ADMIN_EMAILS)
-ADMIN_TEST_USER=admin@example.com
-ADMIN_TEST_PASSWORD=your-password
-
-# Test credentials for non-admin user (for rejection tests)
-TEST_USER=nonadmin@example.com
-TEST_PASSWORD=your-password
+VITE_GITHUB_BRANCH=main

--- a/admin/.env.prod.example
+++ b/admin/.env.prod.example
@@ -1,0 +1,5 @@
+# Production Proxy Configuration
+# Copy this file to .env.prod for use with: npm run dev:prod
+
+# Cloudflare Worker proxy URL
+VITE_PROXY_URL=https://een-oauth-proxy.your-subdomain.workers.dev

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-admin",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-admin",
-      "version": "1.0.29",
+      "version": "1.0.30",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-admin",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-admin",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-admin",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-admin",
-      "version": "1.0.30",
+      "version": "1.0.31",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-admin",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-admin",
-      "version": "1.0.31",
+      "version": "1.0.32",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-admin",
   "displayName": "EEN OAuth Proxy Admin",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "private": true,
   "type": "module",
   "scripts": {
     "dev": "npm run stop && vite",
-    "dev:prod": "npm run stop && VITE_PROXY_URL=$VITE_PROD_PROXY_URL vite",
+    "dev:prod": "vite --mode prod",
     "stop": "lsof -ti :3333 | xargs kill -9 2>/dev/null || echo 'Port 3333 is free'",
     "build": "vite build",
     "preview": "vite preview",

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-admin",
   "displayName": "EEN OAuth Proxy Admin",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "private": true,
   "type": "module",
   "scripts": {
     "dev": "npm run stop && vite",
-    "dev:prod": "vite --mode prod",
+    "dev:prod": "npm run stop && vite --mode prod",
     "stop": "lsof -ti :3333 | xargs kill -9 2>/dev/null || echo 'Port 3333 is free'",
     "build": "vite build",
     "preview": "vite preview",

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-admin",
   "displayName": "EEN OAuth Proxy Admin",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "private": true,
   "type": "module",
   "scripts": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-admin",
   "displayName": "EEN OAuth Proxy Admin",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "private": true,
   "type": "module",
   "scripts": {

--- a/admin/vite-plugin-csp.js
+++ b/admin/vite-plugin-csp.js
@@ -14,15 +14,29 @@ import { loadEnv } from 'vite'
  */
 export function cspPlugin() {
   let proxyUrl = 'http://localhost:8787'
+  let configInitialized = false
   
   return {
     name: 'csp-plugin',
     configResolved(config) {
-      // Load environment variables based on Vite's mode
-      const env = loadEnv(config.mode, process.cwd(), 'VITE_')
-      proxyUrl = env.VITE_PROXY_URL || 'http://localhost:8787'
+      // Defensive validation for config.mode
+      const mode = config?.mode || 'development'
+      try {
+        // Load environment variables based on Vite's mode
+        const env = loadEnv(mode, process.cwd(), 'VITE_')
+        proxyUrl = env.VITE_PROXY_URL || 'http://localhost:8787'
+        configInitialized = true
+      } catch (error) {
+        console.warn(`CSP plugin: Failed to load environment variables for mode "${mode}":`, error.message)
+        // Keep default proxyUrl
+        configInitialized = true
+      }
     },
     transformIndexHtml(html) {
+      // Lifecycle check: warn if configResolved wasn't called
+      if (!configInitialized) {
+        console.warn('CSP plugin: transformIndexHtml called before configResolved, using default proxy URL')
+      }
       
       // Build connect-src directive - always include localhost for dev compatibility
       // Users can select between localhost and VITE_PROXY_URL at runtime,

--- a/admin/vite-plugin-csp.js
+++ b/admin/vite-plugin-csp.js
@@ -1,3 +1,5 @@
+import { loadEnv } from 'vite'
+
 /**
  * Vite plugin to inject proxy URL into CSP meta tag from VITE_PROXY_URL
  * Dynamically builds the connect-src directive based on environment
@@ -11,10 +13,16 @@
  * if it's different from localhost.
  */
 export function cspPlugin() {
+  let proxyUrl = 'http://localhost:8787'
+  
   return {
     name: 'csp-plugin',
+    configResolved(config) {
+      // Load environment variables based on Vite's mode
+      const env = loadEnv(config.mode, process.cwd(), 'VITE_')
+      proxyUrl = env.VITE_PROXY_URL || 'http://localhost:8787'
+    },
     transformIndexHtml(html) {
-      const proxyUrl = process.env.VITE_PROXY_URL || 'http://localhost:8787'
       
       // Build connect-src directive - always include localhost for dev compatibility
       // Users can select between localhost and VITE_PROXY_URL at runtime,

--- a/admin/vite-plugin-csp.js
+++ b/admin/vite-plugin-csp.js
@@ -19,8 +19,13 @@ export function cspPlugin() {
   return {
     name: 'csp-plugin',
     configResolved(config) {
-      // Defensive validation for config.mode
-      const mode = config?.mode || 'development'
+      // Defensive validation for config.mode - must be a string
+      let mode = 'development'
+      if (config?.mode && typeof config.mode === 'string') {
+        mode = config.mode
+      } else if (config?.mode) {
+        console.warn(`CSP plugin: config.mode is not a string (${typeof config.mode}), using default 'development'`)
+      }
       try {
         // Load environment variables based on Vite's mode
         const env = loadEnv(mode, process.cwd(), 'VITE_')

--- a/admin/vite-plugin-csp.test.js
+++ b/admin/vite-plugin-csp.test.js
@@ -4,27 +4,41 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { cspPlugin } from './vite-plugin-csp.js'
+
+// Mock vite's loadEnv before importing the plugin
+let mockProxyUrl = 'http://localhost:8787'
+vi.mock('vite', () => ({
+  loadEnv: () => ({
+    VITE_PROXY_URL: mockProxyUrl
+  })
+}))
+
+// Import plugin after mock is set up
+const { cspPlugin } = await import('./vite-plugin-csp.js')
 
 describe('CSP Plugin URL Matching', () => {
-  let originalEnv
-
   beforeEach(() => {
-    // Save original env
-    originalEnv = { ...process.env }
-    // Clear VITE_PROXY_URL for each test
-    delete process.env.VITE_PROXY_URL
+    // Reset to default
+    mockProxyUrl = 'http://localhost:8787'
   })
 
   afterEach(() => {
-    // Restore original env
-    process.env = originalEnv
+    vi.clearAllMocks()
   })
+
+  // Helper to create and initialize plugin
+  function createPlugin(proxyUrl = 'http://localhost:8787') {
+    mockProxyUrl = proxyUrl
+    const plugin = cspPlugin()
+    // Simulate Vite calling configResolved
+    plugin.configResolved({ mode: 'development' })
+    return plugin
+  }
 
   describe('Localhost Detection', () => {
     it('should detect localhost correctly', () => {
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\' http://localhost:8787;" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('http://localhost:8787')
       const result = plugin.transformIndexHtml(html)
       
       // Should not add localhost again if already present
@@ -33,9 +47,8 @@ describe('CSP Plugin URL Matching', () => {
     })
 
     it('should detect 127.0.0.1 correctly', () => {
-      process.env.VITE_PROXY_URL = 'http://127.0.0.1:8787'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('http://127.0.0.1:8787')
       const result = plugin.transformIndexHtml(html)
       
       // Should not add 127.0.0.1 if it's already in the default list
@@ -47,9 +60,8 @@ describe('CSP Plugin URL Matching', () => {
     })
 
     it('should detect IPv6 localhost [::1]', () => {
-      process.env.VITE_PROXY_URL = 'http://[::1]:8787'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('http://[::1]:8787')
       const result = plugin.transformIndexHtml(html)
       
       // Should not add [::1] as it's a localhost variant
@@ -58,9 +70,8 @@ describe('CSP Plugin URL Matching', () => {
     })
 
     it('should detect 127.x.x.x subnets', () => {
-      process.env.VITE_PROXY_URL = 'http://127.1.2.3:8787'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('http://127.1.2.3:8787')
       const result = plugin.transformIndexHtml(html)
       
       // Should not add 127.x.x.x as it's a localhost variant
@@ -69,9 +80,8 @@ describe('CSP Plugin URL Matching', () => {
     })
 
     it('should detect .localhost TLD', () => {
-      process.env.VITE_PROXY_URL = 'http://myapp.localhost:8787'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('http://myapp.localhost:8787')
       const result = plugin.transformIndexHtml(html)
       
       // Should not add .localhost domains as they're localhost variants
@@ -82,9 +92,8 @@ describe('CSP Plugin URL Matching', () => {
 
   describe('False Positive Prevention', () => {
     it('should not match "my-localhost-server.com" as localhost', () => {
-      process.env.VITE_PROXY_URL = 'https://my-localhost-server.com'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('https://my-localhost-server.com')
       const result = plugin.transformIndexHtml(html)
       
       // Should add the URL since it's not actually localhost
@@ -93,9 +102,8 @@ describe('CSP Plugin URL Matching', () => {
     })
 
     it('should not match "127example.com" as localhost', () => {
-      process.env.VITE_PROXY_URL = 'https://127example.com'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('https://127example.com')
       const result = plugin.transformIndexHtml(html)
       
       // Should add the URL since it's not actually 127.x.x.x
@@ -104,9 +112,8 @@ describe('CSP Plugin URL Matching', () => {
     })
 
     it('should handle URLs with different ports correctly', () => {
-      process.env.VITE_PROXY_URL = 'http://localhost:9999'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('http://localhost:9999')
       const result = plugin.transformIndexHtml(html)
       
       // Should not add localhost:9999 as it's still localhost
@@ -115,9 +122,8 @@ describe('CSP Plugin URL Matching', () => {
     })
 
     it('should handle duplicate URLs correctly', () => {
-      process.env.VITE_PROXY_URL = 'https://example.com'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\' https://example.com;" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('https://example.com')
       const result = plugin.transformIndexHtml(html)
       
       // Should not duplicate the URL
@@ -127,9 +133,8 @@ describe('CSP Plugin URL Matching', () => {
     })
 
     it('should handle URLs with same hostname but different protocols', () => {
-      process.env.VITE_PROXY_URL = 'https://example.com'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\' http://example.com;" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('https://example.com')
       const result = plugin.transformIndexHtml(html)
       
       // Plugin replaces entire connect-src, so https://example.com should be added
@@ -144,7 +149,7 @@ describe('CSP Plugin URL Matching', () => {
   describe('Wildcard Validation', () => {
     it('should allow the specific EEN wildcard pattern', () => {
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin()
       const result = plugin.transformIndexHtml(html)
       
       // Should include the allowed wildcard
@@ -156,7 +161,7 @@ describe('CSP Plugin URL Matching', () => {
       // This test verifies the validation logic works
       // We can't easily test this without modifying the plugin, but the logic is covered
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin()
       
       // The default CSP includes the allowed wildcard, so this should pass
       expect(() => plugin.transformIndexHtml(html)).not.toThrow()
@@ -164,7 +169,7 @@ describe('CSP Plugin URL Matching', () => {
 
     it('should warn if allowed wildcard appears multiple times', () => {
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin()
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       
       // The default implementation shouldn't create duplicates, but test the warning logic
@@ -179,9 +184,8 @@ describe('CSP Plugin URL Matching', () => {
 
   describe('URL Parsing Edge Cases', () => {
     it('should handle invalid URLs gracefully', () => {
-      process.env.VITE_PROXY_URL = 'not-a-valid-url'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('not-a-valid-url')
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       
       const result = plugin.transformIndexHtml(html)
@@ -195,9 +199,8 @@ describe('CSP Plugin URL Matching', () => {
     })
 
     it('should handle empty VITE_PROXY_URL', () => {
-      process.env.VITE_PROXY_URL = ''
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('')
       const result = plugin.transformIndexHtml(html)
       
       // Should use default localhost
@@ -206,9 +209,8 @@ describe('CSP Plugin URL Matching', () => {
     })
 
     it('should handle URLs with paths', () => {
-      process.env.VITE_PROXY_URL = 'https://example.com/api'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('https://example.com/api')
       const result = plugin.transformIndexHtml(html)
       
       // Should add the full URL including path

--- a/demo1/.env.example
+++ b/demo1/.env.example
@@ -1,23 +1,14 @@
-# EEN OAuth Demo - Environment Variables
+# Demo1 Environment Variables
 # Copy this file to .env and fill in your values
 
-# Proxy URL for local development (used by npm run dev)
-VITE_PROXY_URL=http://localhost:8787
-
-# Production proxy URL (used by npm run dev:prod)
-# Set this to your deployed Cloudflare Worker URL
-VITE_PROD_PROXY_URL=https://your-proxy.your-subdomain.workers.dev
-
-# EEN OAuth settings
+# EEN OAuth Client ID (required for login)
 VITE_EEN_CLIENT_ID=your-een-client-id
-VITE_EEN_AUTH_URL=https://auth.eagleeyenetworks.com/oauth2/authorize
 
-# Redirect URI (must match your OAuth app configuration)
-# Local development:
-VITE_REDIRECT_URI=http://127.0.0.1:3333
+# Test credentials for Playwright tests
+# These are used by: npm run test
+TEST_USER=your-test-email@example.com
+TEST_PASSWORD=your-test-password
 
-# Production (must exactly match your EEN OAuth app configuration):
-# VITE_REDIRECT_URI=https://your-username.github.io/een-oauth-proxy
-
-# GitHub repository URL (for version link in UI)
+# GitHub repository info (optional, for version links)
 VITE_GITHUB_REPO=https://github.com/your-username/een-oauth-proxy
+VITE_GITHUB_BRANCH=main

--- a/demo1/.env.example
+++ b/demo1/.env.example
@@ -1,5 +1,13 @@
 # Demo1 Environment Variables
 # Copy this file to .env and fill in your values
+#
+# MODE-BASED LOADING:
+# - .env is loaded for all modes (npm run dev, npm run dev:prod)
+# - .env.prod is loaded ONLY for prod mode (npm run dev:prod)
+# - .env.local and .env.prod.local are gitignored for secrets
+#
+# For local development with local proxy: just create .env
+# For testing with Cloudflare proxy: also create .env.prod (see .env.prod.example)
 
 # EEN OAuth Client ID (required for login)
 VITE_EEN_CLIENT_ID=your-een-client-id

--- a/demo1/.env.prod.example
+++ b/demo1/.env.prod.example
@@ -1,0 +1,5 @@
+# Production Proxy Configuration
+# Copy this file to .env.prod for use with: npm run dev:prod
+
+# Cloudflare Worker proxy URL
+VITE_PROXY_URL=https://een-oauth-proxy.your-subdomain.workers.dev

--- a/demo1/package-lock.json
+++ b/demo1/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-demo1",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-demo1",
-      "version": "0.0.34",
+      "version": "0.0.35",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/demo1/package-lock.json
+++ b/demo1/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-demo1",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-demo1",
-      "version": "0.0.35",
+      "version": "0.0.36",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/demo1/package-lock.json
+++ b/demo1/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-demo1",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-demo1",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/demo1/package-lock.json
+++ b/demo1/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-demo1",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-demo1",
-      "version": "0.0.36",
+      "version": "0.0.37",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/demo1/package.json
+++ b/demo1/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-demo1",
   "displayName": "EEN OAuth Demo1",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "private": true,
   "type": "module",
   "scripts": {

--- a/demo1/package.json
+++ b/demo1/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-demo1",
   "displayName": "EEN OAuth Demo1",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "private": true,
   "type": "module",
   "scripts": {

--- a/demo1/package.json
+++ b/demo1/package.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-demo1",
   "displayName": "EEN OAuth Demo1",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "private": true,
   "type": "module",
   "scripts": {
     "dev": "npm run stop && vite",
-    "dev:prod": "vite --mode prod",
+    "dev:prod": "npm run stop && vite --mode prod",
     "stop": "lsof -ti :3333 | xargs kill -9 2>/dev/null || echo 'Port 3333 is free'",
     "build": "vite build",
     "preview": "vite preview",

--- a/demo1/package.json
+++ b/demo1/package.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-demo1",
   "displayName": "EEN OAuth Demo1",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "private": true,
   "type": "module",
   "scripts": {
     "dev": "npm run stop && vite",
-    "dev:prod": "npm run stop && VITE_PROXY_URL=$VITE_PROD_PROXY_URL vite",
+    "dev:prod": "vite --mode prod",
     "stop": "lsof -ti :3333 | xargs kill -9 2>/dev/null || echo 'Port 3333 is free'",
     "build": "vite build",
     "preview": "vite preview",

--- a/demo1/src/views/Profile.vue
+++ b/demo1/src/views/Profile.vue
@@ -20,9 +20,14 @@
 
       <!-- Profile content -->
       <div v-else class="space-y-6">
-        <!-- Header row with title and version -->
+        <!-- Header row with title, proxy URL, and version -->
         <div class="flex justify-between items-center">
-          <h1 class="text-2xl font-bold text-gray-900">{{ appTitle }}</h1>
+          <div class="flex items-center gap-4">
+            <h1 class="text-2xl font-bold text-gray-900">{{ appTitle }}</h1>
+            <span class="text-sm text-gray-500">
+              OAuth Proxy: <span class="font-mono text-gray-700">{{ proxyUrl }}</span>
+            </span>
+          </div>
           <a
             :href="githubRepoUrl"
             target="_blank"
@@ -185,6 +190,7 @@ import { useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 import { getUserProfile } from '../services/user'
 import { refreshToken as refreshTokenService } from '../services/auth'
+import { getProxyUrl } from '../services/proxy'
 import packageJson from '../../package.json'
 
 const router = useRouter()
@@ -207,6 +213,7 @@ const githubRepoUrl = computed(() => {
   const branch = import.meta.env.VITE_GITHUB_BRANCH || 'develop'
   return `${baseUrl}/tree/${branch}`
 })
+const proxyUrl = computed(() => getProxyUrl())
 
 const tokenExpirationText = computed(() => {
   forceUpdate.value // Trigger reactivity

--- a/demo1/vite-plugin-csp.js
+++ b/demo1/vite-plugin-csp.js
@@ -14,15 +14,29 @@ import { loadEnv } from 'vite'
  */
 export function cspPlugin() {
   let proxyUrl = 'http://localhost:8787'
+  let configInitialized = false
   
   return {
     name: 'csp-plugin',
     configResolved(config) {
-      // Load environment variables based on Vite's mode
-      const env = loadEnv(config.mode, process.cwd(), 'VITE_')
-      proxyUrl = env.VITE_PROXY_URL || 'http://localhost:8787'
+      // Defensive validation for config.mode
+      const mode = config?.mode || 'development'
+      try {
+        // Load environment variables based on Vite's mode
+        const env = loadEnv(mode, process.cwd(), 'VITE_')
+        proxyUrl = env.VITE_PROXY_URL || 'http://localhost:8787'
+        configInitialized = true
+      } catch (error) {
+        console.warn(`CSP plugin: Failed to load environment variables for mode "${mode}":`, error.message)
+        // Keep default proxyUrl
+        configInitialized = true
+      }
     },
     transformIndexHtml(html) {
+      // Lifecycle check: warn if configResolved wasn't called
+      if (!configInitialized) {
+        console.warn('CSP plugin: transformIndexHtml called before configResolved, using default proxy URL')
+      }
       
       // Build connect-src directive - always include localhost for dev compatibility
       // Users can select between localhost and VITE_PROXY_URL at runtime,

--- a/demo1/vite-plugin-csp.js
+++ b/demo1/vite-plugin-csp.js
@@ -1,3 +1,5 @@
+import { loadEnv } from 'vite'
+
 /**
  * Vite plugin to inject proxy URL into CSP meta tag from VITE_PROXY_URL
  * Dynamically builds the connect-src directive based on environment
@@ -11,10 +13,16 @@
  * if it's different from localhost.
  */
 export function cspPlugin() {
+  let proxyUrl = 'http://localhost:8787'
+  
   return {
     name: 'csp-plugin',
+    configResolved(config) {
+      // Load environment variables based on Vite's mode
+      const env = loadEnv(config.mode, process.cwd(), 'VITE_')
+      proxyUrl = env.VITE_PROXY_URL || 'http://localhost:8787'
+    },
     transformIndexHtml(html) {
-      const proxyUrl = process.env.VITE_PROXY_URL || 'http://localhost:8787'
       
       // Build connect-src directive - always include localhost for dev compatibility
       // Users can select between localhost and VITE_PROXY_URL at runtime,

--- a/demo1/vite-plugin-csp.js
+++ b/demo1/vite-plugin-csp.js
@@ -19,8 +19,13 @@ export function cspPlugin() {
   return {
     name: 'csp-plugin',
     configResolved(config) {
-      // Defensive validation for config.mode
-      const mode = config?.mode || 'development'
+      // Defensive validation for config.mode - must be a string
+      let mode = 'development'
+      if (config?.mode && typeof config.mode === 'string') {
+        mode = config.mode
+      } else if (config?.mode) {
+        console.warn(`CSP plugin: config.mode is not a string (${typeof config.mode}), using default 'development'`)
+      }
       try {
         // Load environment variables based on Vite's mode
         const env = loadEnv(mode, process.cwd(), 'VITE_')

--- a/demo1/vite-plugin-csp.test.js
+++ b/demo1/vite-plugin-csp.test.js
@@ -4,27 +4,41 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { cspPlugin } from './vite-plugin-csp.js'
+
+// Mock vite's loadEnv before importing the plugin
+let mockProxyUrl = 'http://localhost:8787'
+vi.mock('vite', () => ({
+  loadEnv: () => ({
+    VITE_PROXY_URL: mockProxyUrl
+  })
+}))
+
+// Import plugin after mock is set up
+const { cspPlugin } = await import('./vite-plugin-csp.js')
 
 describe('CSP Plugin URL Matching', () => {
-  let originalEnv
-
   beforeEach(() => {
-    // Save original env
-    originalEnv = { ...process.env }
-    // Clear VITE_PROXY_URL for each test
-    delete process.env.VITE_PROXY_URL
+    // Reset to default
+    mockProxyUrl = 'http://localhost:8787'
   })
 
   afterEach(() => {
-    // Restore original env
-    process.env = originalEnv
+    vi.clearAllMocks()
   })
+
+  // Helper to create and initialize plugin
+  function createPlugin(proxyUrl = 'http://localhost:8787') {
+    mockProxyUrl = proxyUrl
+    const plugin = cspPlugin()
+    // Simulate Vite calling configResolved
+    plugin.configResolved({ mode: 'development' })
+    return plugin
+  }
 
   describe('Localhost Detection', () => {
     it('should detect localhost correctly', () => {
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\' http://localhost:8787;" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('http://localhost:8787')
       const result = plugin.transformIndexHtml(html)
       
       // Should not add localhost again if already present
@@ -33,9 +47,8 @@ describe('CSP Plugin URL Matching', () => {
     })
 
     it('should detect 127.0.0.1 correctly', () => {
-      process.env.VITE_PROXY_URL = 'http://127.0.0.1:8787'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('http://127.0.0.1:8787')
       const result = plugin.transformIndexHtml(html)
       
       // Should not add 127.0.0.1 if it's already in the default list
@@ -47,9 +60,8 @@ describe('CSP Plugin URL Matching', () => {
     })
 
     it('should detect IPv6 localhost [::1]', () => {
-      process.env.VITE_PROXY_URL = 'http://[::1]:8787'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('http://[::1]:8787')
       const result = plugin.transformIndexHtml(html)
       
       // Should not add [::1] as it's a localhost variant
@@ -58,9 +70,8 @@ describe('CSP Plugin URL Matching', () => {
     })
 
     it('should detect 127.x.x.x subnets', () => {
-      process.env.VITE_PROXY_URL = 'http://127.1.2.3:8787'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('http://127.1.2.3:8787')
       const result = plugin.transformIndexHtml(html)
       
       // Should not add 127.x.x.x as it's a localhost variant
@@ -69,9 +80,8 @@ describe('CSP Plugin URL Matching', () => {
     })
 
     it('should detect .localhost TLD', () => {
-      process.env.VITE_PROXY_URL = 'http://myapp.localhost:8787'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('http://myapp.localhost:8787')
       const result = plugin.transformIndexHtml(html)
       
       // Should not add .localhost domains as they're localhost variants
@@ -82,9 +92,8 @@ describe('CSP Plugin URL Matching', () => {
 
   describe('False Positive Prevention', () => {
     it('should not match "my-localhost-server.com" as localhost', () => {
-      process.env.VITE_PROXY_URL = 'https://my-localhost-server.com'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('https://my-localhost-server.com')
       const result = plugin.transformIndexHtml(html)
       
       // Should add the URL since it's not actually localhost
@@ -93,9 +102,8 @@ describe('CSP Plugin URL Matching', () => {
     })
 
     it('should not match "127example.com" as localhost', () => {
-      process.env.VITE_PROXY_URL = 'https://127example.com'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('https://127example.com')
       const result = plugin.transformIndexHtml(html)
       
       // Should add the URL since it's not actually 127.x.x.x
@@ -104,9 +112,8 @@ describe('CSP Plugin URL Matching', () => {
     })
 
     it('should handle URLs with different ports correctly', () => {
-      process.env.VITE_PROXY_URL = 'http://localhost:9999'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('http://localhost:9999')
       const result = plugin.transformIndexHtml(html)
       
       // Should not add localhost:9999 as it's still localhost
@@ -115,9 +122,8 @@ describe('CSP Plugin URL Matching', () => {
     })
 
     it('should handle duplicate URLs correctly', () => {
-      process.env.VITE_PROXY_URL = 'https://example.com'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\' https://example.com;" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('https://example.com')
       const result = plugin.transformIndexHtml(html)
       
       // Should not duplicate the URL
@@ -127,9 +133,8 @@ describe('CSP Plugin URL Matching', () => {
     })
 
     it('should handle URLs with same hostname but different protocols', () => {
-      process.env.VITE_PROXY_URL = 'https://example.com'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\' http://example.com;" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('https://example.com')
       const result = plugin.transformIndexHtml(html)
       
       // Plugin replaces entire connect-src, so https://example.com should be added
@@ -144,7 +149,7 @@ describe('CSP Plugin URL Matching', () => {
   describe('Wildcard Validation', () => {
     it('should allow the specific EEN wildcard pattern', () => {
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin()
       const result = plugin.transformIndexHtml(html)
       
       // Should include the allowed wildcard
@@ -156,7 +161,7 @@ describe('CSP Plugin URL Matching', () => {
       // This test verifies the validation logic works
       // We can't easily test this without modifying the plugin, but the logic is covered
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin()
       
       // The default CSP includes the allowed wildcard, so this should pass
       expect(() => plugin.transformIndexHtml(html)).not.toThrow()
@@ -164,7 +169,7 @@ describe('CSP Plugin URL Matching', () => {
 
     it('should warn if allowed wildcard appears multiple times', () => {
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin()
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       
       // The default implementation shouldn't create duplicates, but test the warning logic
@@ -179,9 +184,8 @@ describe('CSP Plugin URL Matching', () => {
 
   describe('URL Parsing Edge Cases', () => {
     it('should handle invalid URLs gracefully', () => {
-      process.env.VITE_PROXY_URL = 'not-a-valid-url'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('not-a-valid-url')
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       
       const result = plugin.transformIndexHtml(html)
@@ -195,9 +199,8 @@ describe('CSP Plugin URL Matching', () => {
     })
 
     it('should handle empty VITE_PROXY_URL', () => {
-      process.env.VITE_PROXY_URL = ''
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('')
       const result = plugin.transformIndexHtml(html)
       
       // Should use default localhost
@@ -206,9 +209,8 @@ describe('CSP Plugin URL Matching', () => {
     })
 
     it('should handle URLs with paths', () => {
-      process.env.VITE_PROXY_URL = 'https://example.com/api'
       const html = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'; connect-src \'self\';" />'
-      const plugin = cspPlugin()
+      const plugin = createPlugin('https://example.com/api')
       const result = plugin.transformIndexHtml(html)
       
       // Should add the full URL including path
@@ -217,4 +219,3 @@ describe('CSP Plugin URL Matching', () => {
     })
   })
 })
-


### PR DESCRIPTION
## Summary
- Fix CSP plugin in demo1 and admin to properly load environment variables using Vite's `loadEnv` based on mode
- Update `dev:prod` scripts to use `vite --mode prod` instead of shell variable expansion
- Add OAuth Proxy URL display to demo1 Profile dashboard header
- Update CSP plugin tests to mock `loadEnv` properly
- Update `.env.example` files with required variables

## Changes
- `vite-plugin-csp.js` now uses Vite's `configResolved` hook with `loadEnv` to properly read environment variables based on mode
- `npm run dev:prod` now works correctly with `.env.prod` files
- Profile page shows the configured OAuth Proxy URL in the header

## Testing
- All proxy tests pass (237 tests)
- All admin tests pass (38 unit + 16 E2E)
- All demo1 tests pass (11 E2E)