### PR TITLE
Show actual proxy URLs in dropdown and document VITE_GITHUB_REPO

### DIFF
--- a/.claude/skills/PR-and-check/SKILL.md
+++ b/.claude/skills/PR-and-check/SKILL.md
@@ -1,54 +1,53 @@
 ---
 name: PR-and-check
-description: Use this skill when you are requested to create a PR for a feature branch to develop, or from develop to production.
+description: Use this skill when you are requested to create a PR for a feature branch.
 ---
 
 # Instructions
 
-## 1. Validate branch and determine PR target
-- Check current branch: `git branch --show-current`
-- Determine the PR flow:
-  - If on `develop` → create PR to `production`
-  - If on `production` → report error and stop (cannot create PR from production)
-  - If on any other branch (feature branch) → create PR to `develop`
-- Store the target branch for later use
+## 1. Validate branch
+- Verify we're on a feature branch (not `develop` or `production`)
+  - check current branch: `git branch --show-current`
+  - if on `develop` or `production`, report error and stop
 
 ## 2. Check for existing PR
-- Check if a PR already exists for this branch to the target:
-  - `gh pr list --head <branch-name> --base <target-branch> --json number,url`
+- Check if a PR already exists for this branch: `gh pr list --head <branch-name> --json number,url`
 - If a PR exists, report the existing PR URL and skip to step 5 (code review)
 
 ## 3. Run tests locally
-- Run linting first:
-  - run: `npm run lint`
-  - if linting fails, analyse the failure, report findings, and stop
-- Run unit tests:
-  - run: `npm test`
+- Run the proxy API tests first (these don't need a running proxy - they use vitest's mock worker)
+  - run: `npm test` in the `proxy` directory
   - if tests fail, analyse the failure, report findings, and stop
-- Run build to verify compilation:
-  - run: `npm run build`
-  - if build fails, analyse the failure, report findings, and stop
+- Start the local proxy for integration tests
+  - check if proxy is running: `lsof -i :8787 | grep LISTEN`
+  - terminate existing proxy if running: `lsof -i :8787 -t | xargs kill`
+  - start proxy in background: run `npm run dev` in the `proxy` directory with `run_in_background: true`
+  - wait a few seconds for the proxy to start, then verify it's running
+- Run the remaining test suites sequentially - these can not run in parallel as the apps use the same port 3333
+  - run the admin tests: `npm test` in the `admin` directory
+  - run the demo1 tests: `npx playwright test` in the `demo1` directory
+  - if any test fails, analyse the failure, report findings, and stop
+- Cleanup: terminate the local proxy after tests complete
+  - `lsof -i :8787 -t | xargs kill`
 
 ## 4. Create PR
-- Get version number for the PR body:
-  - `jq -r .version package.json`
-- Get list of commits to include:
-  - `git log origin/<target-branch>..HEAD --oneline`
-- Create a well-formatted PR:
-  - use `gh pr create --base <target-branch> --title "<title>" --body "<body>"` with a HEREDOC for the body
-  - highlight the changes and the purpose of the branch
-  - include test results summary and version number
+- Get version numbers for the PR body:
+  - `jq -r .version proxy/package.json` (and similarly for admin, demo1)
+- Create a well-formatted PR from the feature branch to develop:
+  - use `gh pr create --base develop --title "<title>" --body "<body>"` with a HEREDOC for the body
+  - highlight the changes and the purpose of the feature branch
+  - include test results summary and version numbers
 - Capture the PR number from the output (needed for code review step)
   - the `gh pr create` command outputs the PR URL, extract the number from it
 
-## 5. Monitor code review
-- A code review using the workflow claude-code-review.yml was automatically triggered by the PR
+## 5. monitor code review
+- A code review using the workflow pr-review.yml was automatically triggered by the PR
 - Verify the workflow started:
-  - wait 5 seconds, then check: `gh run list --workflow=claude-code-review.yml --limit 1 --json databaseId,status,headBranch`
+  - wait 5 seconds, then check: `gh run list --workflow=pr-review.yml --limit 1 --json databaseId,status,headBranch`
   - confirm the run is for the correct branch
   - if workflow failed to start, report error and stop
 - Poll for completion (check once per minute, max 10 minutes total):
-  - `gh run list --workflow=claude-code-review.yml --limit 1 --json databaseId,status,conclusion`
+  - `gh run list --workflow=pr-review.yml --limit 1 --json databaseId,status,conclusion`
 - Check the result:
   - if the workflow did not finish within 10 minutes, report timeout and stop
   - view the review: `gh pr view <pr-number> --comments` or check the PR review file artifact

--- a/.claude/skills/PR-and-check/SKILL.md
+++ b/.claude/skills/PR-and-check/SKILL.md
@@ -1,53 +1,54 @@
 ---
 name: PR-and-check
-description: Use this skill when you are requested to create a PR for a feature branch.
+description: Use this skill when you are requested to create a PR for a feature branch to develop, or from develop to production.
 ---
 
 # Instructions
 
-## 1. Validate branch
-- Verify we're on a feature branch (not `develop` or `production`)
-  - check current branch: `git branch --show-current`
-  - if on `develop` or `production`, report error and stop
+## 1. Validate branch and determine PR target
+- Check current branch: `git branch --show-current`
+- Determine the PR flow:
+  - If on `develop` → create PR to `production`
+  - If on `production` → report error and stop (cannot create PR from production)
+  - If on any other branch (feature branch) → create PR to `develop`
+- Store the target branch for later use
 
 ## 2. Check for existing PR
-- Check if a PR already exists for this branch: `gh pr list --head <branch-name> --json number,url`
+- Check if a PR already exists for this branch to the target:
+  - `gh pr list --head <branch-name> --base <target-branch> --json number,url`
 - If a PR exists, report the existing PR URL and skip to step 5 (code review)
 
 ## 3. Run tests locally
-- Run the proxy API tests first (these don't need a running proxy - they use vitest's mock worker)
-  - run: `npm test` in the `proxy` directory
+- Run linting first:
+  - run: `npm run lint`
+  - if linting fails, analyse the failure, report findings, and stop
+- Run unit tests:
+  - run: `npm test`
   - if tests fail, analyse the failure, report findings, and stop
-- Start the local proxy for integration tests
-  - check if proxy is running: `lsof -i :8787 | grep LISTEN`
-  - terminate existing proxy if running: `lsof -i :8787 -t | xargs kill`
-  - start proxy in background: run `npm run dev` in the `proxy` directory with `run_in_background: true`
-  - wait a few seconds for the proxy to start, then verify it's running
-- Run the remaining test suites sequentially - these can not run in parallel as the apps use the same port 3333
-  - run the admin tests: `npm test` in the `admin` directory
-  - run the demo1 tests: `npx playwright test` in the `demo1` directory
-  - if any test fails, analyse the failure, report findings, and stop
-- Cleanup: terminate the local proxy after tests complete
-  - `lsof -i :8787 -t | xargs kill`
+- Run build to verify compilation:
+  - run: `npm run build`
+  - if build fails, analyse the failure, report findings, and stop
 
 ## 4. Create PR
-- Get version numbers for the PR body:
-  - `jq -r .version proxy/package.json` (and similarly for admin, demo1)
-- Create a well-formatted PR from the feature branch to develop:
-  - use `gh pr create --base develop --title "<title>" --body "<body>"` with a HEREDOC for the body
-  - highlight the changes and the purpose of the feature branch
-  - include test results summary and version numbers
+- Get version number for the PR body:
+  - `jq -r .version package.json`
+- Get list of commits to include:
+  - `git log origin/<target-branch>..HEAD --oneline`
+- Create a well-formatted PR:
+  - use `gh pr create --base <target-branch> --title "<title>" --body "<body>"` with a HEREDOC for the body
+  - highlight the changes and the purpose of the branch
+  - include test results summary and version number
 - Capture the PR number from the output (needed for code review step)
   - the `gh pr create` command outputs the PR URL, extract the number from it
 
-## 5. monitor code review
-- A code review using the workflow pr-review.yml was automatically triggered by the PR
+## 5. Monitor code review
+- A code review using the workflow claude-code-review.yml was automatically triggered by the PR
 - Verify the workflow started:
-  - wait 5 seconds, then check: `gh run list --workflow=pr-review.yml --limit 1 --json databaseId,status,headBranch`
+  - wait 5 seconds, then check: `gh run list --workflow=claude-code-review.yml --limit 1 --json databaseId,status,headBranch`
   - confirm the run is for the correct branch
   - if workflow failed to start, report error and stop
 - Poll for completion (check once per minute, max 10 minutes total):
-  - `gh run list --workflow=pr-review.yml --limit 1 --json databaseId,status,conclusion`
+  - `gh run list --workflow=claude-code-review.yml --limit 1 --json databaseId,status,conclusion`
 - Check the result:
   - if the workflow did not finish within 10 minutes, report timeout and stop
   - view the review: `gh pr view <pr-number> --comments` or check the PR review file artifact

--- a/.github/workflows/check-proxy-version.yml
+++ b/.github/workflows/check-proxy-version.yml
@@ -1,3 +1,7 @@
+# This workflow runs on PRs to production branch when proxy code changes.
+# It checks if the proxy version in the PR differs from the deployed version.
+# A version mismatch indicates manual deployment will be needed post-merge
+# (Cloudflare secrets are not stored in GitHub, so deployment must be done locally).
 name: Check Proxy Deployment Status
 
 on:
@@ -66,9 +70,13 @@ jobs:
           else
             # Try to grab just the version if the format is different or simple
             DEPLOYED_VERSION=$(echo "$FULL_VERSION" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+            if [ -n "$DEPLOYED_VERSION" ]; then
+              echo "::notice::Version format different than expected, extracted: $DEPLOYED_VERSION from: $FULL_VERSION"
+            fi
           fi
-          
+
           if [ -z "$DEPLOYED_VERSION" ]; then
+             echo "::warning::Failed to parse semantic version from: $FULL_VERSION"
              DEPLOYED_VERSION="unknown"
           fi
           

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -35,29 +35,35 @@ increment_version() {
     fi
 }
 
-# Check if proxy folder has staged changes
-if git diff --cached --name-only | grep -q "^proxy/"; then
+# Cache staged files to avoid multiple git diff calls
+STAGED_FILES=$(git diff --cached --name-only)
+
+# Check which folders have staged changes
+proxy_has_changes=$(echo "$STAGED_FILES" | grep -q "^proxy/" && echo "1" || echo "0")
+demo1_has_changes=$(echo "$STAGED_FILES" | grep -q "^demo1/" && echo "1" || echo "0")
+admin_has_changes=$(echo "$STAGED_FILES" | grep -q "^admin/" && echo "1" || echo "0")
+
+# Increment versions for folders with changes
+if [ "$proxy_has_changes" = "1" ]; then
     if ! increment_version "proxy"; then
         exit 1
     fi
 fi
 
-# Check if demo1 folder has staged changes
-if git diff --cached --name-only | grep -q "^demo1/"; then
+if [ "$demo1_has_changes" = "1" ]; then
     if ! increment_version "demo1"; then
         exit 1
     fi
 fi
 
-# Check if admin folder has staged changes
-if git diff --cached --name-only | grep -q "^admin/"; then
+if [ "$admin_has_changes" = "1" ]; then
     if ! increment_version "admin"; then
         exit 1
     fi
 fi
 
-# Check if proxy folder has staged changes - if so, check deployment status
-if git diff --cached --name-only | grep -q "^proxy/"; then
+# Check deployment status if proxy has changes
+if [ "$proxy_has_changes" = "1" ]; then
     if [ "${SKIP_DEPLOYMENT_CHECK:-0}" != "1" ]; then
         echo ""
         echo "Checking proxy deployment status..."

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ Both demo1 and admin apps support mode-based environment loading:
 
 The `.env.prod` file should contain `VITE_PROXY_URL` pointing to your deployed Cloudflare Worker.
 
+> **Security Note**: `.env.prod` files are gitignored. Never commit production URLs with sensitive paths or tokens.
+
 **Demo App (`./demo1`):**
 ```bash
 cd demo1
@@ -769,6 +771,10 @@ The same applies to the `demo1` application.
 ### "Forbidden: Invalid origin" error
 - Check that the request origin is in `ALLOWED_ORIGINS`
 - In development, only `http://127.0.0.1:3333` is automatically allowed (to match EEN OAuth redirect URI)
+- **Security Note**: Including `http://127.0.0.1:3333` in production `ALLOWED_ORIGINS` is safe because:
+  - Browsers enforce the Same-Origin Policy, preventing remote sites from making requests that appear to come from localhost
+  - Only code actually running on localhost can send requests with a `127.0.0.1` origin
+  - This allows developers to test against the production proxy while developing locally
 
 ### "Admin access required" error
 - Ensure your email is in the `ADMIN_EMAILS` list

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ cp .env.prod.example .env.prod  # Optional: for testing with Cloudflare proxy
 Edit `demo1/.env`:
 ```env
 VITE_EEN_CLIENT_ID=your-een-client-id
+VITE_GITHUB_REPO=https://github.com/your-username/een-oauth-proxy
 TEST_USER=your-test-email@example.com
 TEST_PASSWORD=your-test-password
 ```
@@ -204,6 +205,7 @@ cp .env.prod.example .env.prod  # Optional: for testing with Cloudflare proxy
 Edit `admin/.env`:
 ```env
 VITE_EEN_CLIENT_ID=your-een-client-id
+VITE_GITHUB_REPO=https://github.com/your-username/een-oauth-proxy
 ADMIN_TEST_USER=your-admin-email@example.com
 ADMIN_TEST_PASSWORD=your-admin-password
 ```
@@ -658,6 +660,7 @@ Values outside the min/max range are automatically clamped. Adjust this value ba
 | `VITE_EEN_CLIENT_ID` | EEN OAuth Client ID | `YOUR-CLIENT-ID` |
 | `VITE_EEN_AUTH_URL` | EEN OAuth authorize URL | `https://auth.eagleeyenetworks.com/oauth2/authorize` |
 | `VITE_REDIRECT_URI` | OAuth callback URL (must exactly match EEN config) | `http://127.0.0.1:3333` |
+| `VITE_GITHUB_REPO` | GitHub repository URL for version links in the app footer | `https://github.com/your-username/een-oauth-proxy` |
 
 ## API Endpoints
 

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-admin",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-admin",
-      "version": "1.0.33",
+      "version": "1.0.34",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-admin",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-admin",
-      "version": "1.0.32",
+      "version": "1.0.33",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-admin",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-admin",
-      "version": "1.0.34",
+      "version": "1.0.35",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-admin",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-admin",
-      "version": "1.0.35",
+      "version": "1.0.36",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-admin",
   "displayName": "EEN OAuth Proxy Admin",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "private": true,
   "type": "module",
   "scripts": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-admin",
   "displayName": "EEN OAuth Proxy Admin",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "private": true,
   "type": "module",
   "scripts": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-admin",
   "displayName": "EEN OAuth Proxy Admin",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "private": true,
   "type": "module",
   "scripts": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-admin",
   "displayName": "EEN OAuth Proxy Admin",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "private": true,
   "type": "module",
   "scripts": {

--- a/admin/src/services/admin.js
+++ b/admin/src/services/admin.js
@@ -71,6 +71,21 @@ export function isValidProxyUrl(url) {
 }
 
 /**
+ * Format a proxy URL for display in dropdown
+ * Shows hostname and port only to prevent overly long labels
+ * @param {string} url - Full proxy URL
+ * @returns {string} - Formatted label (hostname:port or hostname)
+ */
+function formatProxyLabel(url) {
+  try {
+    const urlObj = new URL(url)
+    return urlObj.hostname + (urlObj.port ? `:${urlObj.port}` : '')
+  } catch {
+    return url
+  }
+}
+
+/**
  * Get available proxy options based on environment
  * - In production: only the configured VITE_PROXY_URL
  * - In development: local and configured options
@@ -81,12 +96,12 @@ export function getProxyOptions() {
   // In production, only show configured proxy; in dev, show local option too
   if (isProduction()) {
     if (ENV_PROXY_URL) {
-      options.push({ label: ENV_PROXY_URL, value: ENV_PROXY_URL })
+      options.push({ label: formatProxyLabel(ENV_PROXY_URL), value: ENV_PROXY_URL })
     }
   } else {
-    options.push({ label: LOCAL_PROXY_URL, value: LOCAL_PROXY_URL })
+    options.push({ label: formatProxyLabel(LOCAL_PROXY_URL), value: LOCAL_PROXY_URL })
     if (ENV_PROXY_URL && ENV_PROXY_URL !== LOCAL_PROXY_URL) {
-      options.push({ label: ENV_PROXY_URL, value: ENV_PROXY_URL })
+      options.push({ label: formatProxyLabel(ENV_PROXY_URL), value: ENV_PROXY_URL })
     }
   }
 

--- a/admin/src/services/admin.js
+++ b/admin/src/services/admin.js
@@ -81,12 +81,12 @@ export function getProxyOptions() {
   // In production, only show configured proxy; in dev, show local option too
   if (isProduction()) {
     if (ENV_PROXY_URL) {
-      options.push({ label: 'Configured Proxy', value: ENV_PROXY_URL })
+      options.push({ label: ENV_PROXY_URL, value: ENV_PROXY_URL })
     }
   } else {
-    options.push({ label: 'Local (localhost:8787)', value: LOCAL_PROXY_URL })
+    options.push({ label: LOCAL_PROXY_URL, value: LOCAL_PROXY_URL })
     if (ENV_PROXY_URL && ENV_PROXY_URL !== LOCAL_PROXY_URL) {
-      options.push({ label: 'Configured Proxy', value: ENV_PROXY_URL })
+      options.push({ label: ENV_PROXY_URL, value: ENV_PROXY_URL })
     }
   }
 

--- a/admin/vite-plugin-csp.js
+++ b/admin/vite-plugin-csp.js
@@ -80,8 +80,9 @@ export function cspPlugin() {
           
           // Only add if not already in list and not a localhost variant
           // Use hostname comparison instead of string includes to avoid false positives
-          const isLocalhost = proxyHostname === 'localhost' || 
-                             proxyHostname === '127.0.0.1' || 
+          const isLocalhost = proxyHostname === 'localhost' ||
+                             proxyHostname === '127.0.0.1' ||
+                             proxyHostname === '0.0.0.0' ||
                              proxyHostname === '[::1]' ||
                              proxyHostname.startsWith('127.') ||
                              proxyHostname.endsWith('.localhost')

--- a/admin/vite-plugin-csp.js
+++ b/admin/vite-plugin-csp.js
@@ -23,8 +23,10 @@ export function cspPlugin() {
       let mode = 'development'
       if (config?.mode && typeof config.mode === 'string') {
         mode = config.mode
-      } else if (config?.mode) {
-        console.warn(`CSP plugin: config.mode is not a string (${typeof config.mode}), using default 'development'`)
+      } else if (!config?.mode) {
+        console.warn('CSP plugin: config.mode is undefined, defaulting to development')
+      } else {
+        console.error(`CSP plugin: config.mode has invalid type (${typeof config.mode}), defaulting to development`)
       }
       try {
         // Load environment variables based on Vite's mode

--- a/demo1/package-lock.json
+++ b/demo1/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-demo1",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-demo1",
-      "version": "0.0.37",
+      "version": "0.0.38",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/demo1/package-lock.json
+++ b/demo1/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-demo1",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-demo1",
-      "version": "0.0.40",
+      "version": "0.0.41",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/demo1/package-lock.json
+++ b/demo1/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-demo1",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-demo1",
-      "version": "0.0.39",
+      "version": "0.0.40",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/demo1/package-lock.json
+++ b/demo1/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-demo1",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-demo1",
-      "version": "0.0.38",
+      "version": "0.0.39",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/demo1/package.json
+++ b/demo1/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-demo1",
   "displayName": "EEN OAuth Demo1",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "private": true,
   "type": "module",
   "scripts": {

--- a/demo1/package.json
+++ b/demo1/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-demo1",
   "displayName": "EEN OAuth Demo1",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "private": true,
   "type": "module",
   "scripts": {

--- a/demo1/package.json
+++ b/demo1/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-demo1",
   "displayName": "EEN OAuth Demo1",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "private": true,
   "type": "module",
   "scripts": {

--- a/demo1/package.json
+++ b/demo1/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-demo1",
   "displayName": "EEN OAuth Demo1",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "private": true,
   "type": "module",
   "scripts": {

--- a/demo1/src/services/proxy.js
+++ b/demo1/src/services/proxy.js
@@ -40,6 +40,21 @@ function isProduction() {
 }
 
 /**
+ * Format a proxy URL for display in dropdown
+ * Shows hostname and port only to prevent overly long labels
+ * @param {string} url - Full proxy URL
+ * @returns {string} - Formatted label (hostname:port or hostname)
+ */
+function formatProxyLabel(url) {
+  try {
+    const urlObj = new URL(url)
+    return urlObj.hostname + (urlObj.port ? `:${urlObj.port}` : '')
+  } catch {
+    return url
+  }
+}
+
+/**
  * Get available proxy options based on environment
  * - In production: only the configured VITE_PROXY_URL
  * - In development: local and configured options
@@ -50,12 +65,12 @@ export function getProxyOptions() {
   // In production, only show configured proxy; in dev, show local option too
   if (isProduction()) {
     if (ENV_PROXY_URL) {
-      options.push({ label: ENV_PROXY_URL, value: ENV_PROXY_URL })
+      options.push({ label: formatProxyLabel(ENV_PROXY_URL), value: ENV_PROXY_URL })
     }
   } else {
-    options.push({ label: LOCAL_PROXY_URL, value: LOCAL_PROXY_URL })
+    options.push({ label: formatProxyLabel(LOCAL_PROXY_URL), value: LOCAL_PROXY_URL })
     if (ENV_PROXY_URL && ENV_PROXY_URL !== LOCAL_PROXY_URL) {
-      options.push({ label: ENV_PROXY_URL, value: ENV_PROXY_URL })
+      options.push({ label: formatProxyLabel(ENV_PROXY_URL), value: ENV_PROXY_URL })
     }
   }
 

--- a/demo1/src/services/proxy.js
+++ b/demo1/src/services/proxy.js
@@ -81,8 +81,9 @@ export function getProxyOptions() {
  * Validate if a URL is an allowed proxy URL
  * @param {string} url - URL to validate
  * @returns {boolean} - True if URL is valid and allowed
+ * @exported for testing
  */
-function isValidProxyUrl(url) {
+export function isValidProxyUrl(url) {
   try {
     const parsedUrl = new URL(url)
     const hostname = parsedUrl.hostname

--- a/demo1/src/services/proxy.js
+++ b/demo1/src/services/proxy.js
@@ -50,12 +50,12 @@ export function getProxyOptions() {
   // In production, only show configured proxy; in dev, show local option too
   if (isProduction()) {
     if (ENV_PROXY_URL) {
-      options.push({ label: 'Configured Proxy', value: ENV_PROXY_URL })
+      options.push({ label: ENV_PROXY_URL, value: ENV_PROXY_URL })
     }
   } else {
-    options.push({ label: 'Local (localhost:8787)', value: LOCAL_PROXY_URL })
+    options.push({ label: LOCAL_PROXY_URL, value: LOCAL_PROXY_URL })
     if (ENV_PROXY_URL && ENV_PROXY_URL !== LOCAL_PROXY_URL) {
-      options.push({ label: 'Configured Proxy', value: ENV_PROXY_URL })
+      options.push({ label: ENV_PROXY_URL, value: ENV_PROXY_URL })
     }
   }
 

--- a/demo1/vite-plugin-csp.js
+++ b/demo1/vite-plugin-csp.js
@@ -80,8 +80,9 @@ export function cspPlugin() {
           
           // Only add if not already in list and not a localhost variant
           // Use hostname comparison instead of string includes to avoid false positives
-          const isLocalhost = proxyHostname === 'localhost' || 
-                             proxyHostname === '127.0.0.1' || 
+          const isLocalhost = proxyHostname === 'localhost' ||
+                             proxyHostname === '127.0.0.1' ||
+                             proxyHostname === '0.0.0.0' ||
                              proxyHostname === '[::1]' ||
                              proxyHostname.startsWith('127.') ||
                              proxyHostname.endsWith('.localhost')

--- a/demo1/vite-plugin-csp.js
+++ b/demo1/vite-plugin-csp.js
@@ -23,8 +23,10 @@ export function cspPlugin() {
       let mode = 'development'
       if (config?.mode && typeof config.mode === 'string') {
         mode = config.mode
-      } else if (config?.mode) {
-        console.warn(`CSP plugin: config.mode is not a string (${typeof config.mode}), using default 'development'`)
+      } else if (!config?.mode) {
+        console.warn('CSP plugin: config.mode is undefined, defaulting to development')
+      } else {
+        console.error(`CSP plugin: config.mode has invalid type (${typeof config.mode}), defaulting to development`)
       }
       try {
         // Load environment variables based on Vite's mode

--- a/scripts/check-deployment.sh
+++ b/scripts/check-deployment.sh
@@ -8,6 +8,12 @@
 
 set -euo pipefail
 
+# Check node is available (required for JSON parsing)
+if ! command -v node &> /dev/null; then
+    echo "Error: node is required but not installed"
+    exit 1
+fi
+
 PROXY_URL="${PROXY_URL:-https://een-oauth-proxy.klaushofrichter.workers.dev}"
 
 # Validate PROXY_URL format to prevent command injection


### PR DESCRIPTION
## Summary

- Update admin and demo1 proxy selection dropdowns to display actual URLs instead of generic labels like "Configured Proxy" or "Local (localhost:8787)"
- Add `VITE_GITHUB_REPO` documentation to README for configuring repository links in app footers

## Changes

- **admin/src/services/admin.js**: Changed `getProxyOptions()` to use actual URL values as labels
- **demo1/src/services/proxy.js**: Changed `getProxyOptions()` to use actual URL values as labels  
- **README.md**: Added `VITE_GITHUB_REPO` environment variable documentation in:
  - demo1/.env example
  - admin/.env example
  - App Environment Variables reference table

## Test Results

All tests passed locally:
- ✅ Proxy API tests (Vitest): All passed
- ✅ Admin Playwright tests: 16/16 passed
- ✅ Demo1 Playwright tests: 11/11 passed

## Versions

| Component | Version |
|-----------|---------|
| Proxy | 1.2.16 |
| Admin | 1.0.33 |
| Demo1 | 0.0.38 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)