### PR TITLE
Add Cloudflare proxy deployment workflow

### DIFF
--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -78,8 +78,8 @@ jobs:
           cd proxy
           DEPLOY_TIME=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
           VERSION_STRING="een-oauth-proxy - ${{ steps.version.outputs.version }} - $DEPLOY_TIME"
-          # Get namespace ID using wrangler CLI
-          NAMESPACE_ID=$(npx wrangler kv namespace list --json | jq -r '.[] | select(.title | contains("EEN_OAUTH_SESSIONS")) | .id')
+          # Get namespace ID using wrangler CLI (exact match on title)
+          NAMESPACE_ID=$(npx wrangler kv namespace list --json | jq -r '.[] | select(.title == "een-oauth-proxy-EEN_OAUTH_SESSIONS") | .id')
           # Validate namespace ID was found
           if [ -z "$NAMESPACE_ID" ]; then
             echo "Error: Could not find KV namespace EEN_OAUTH_SESSIONS"
@@ -114,7 +114,8 @@ jobs:
         if: success()
         continue-on-error: true
         run: |
-          curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+          # Mask webhook URL in any error output
+          curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H "Content-Type: application/json" \
             -d '{
               "blocks": [
@@ -169,7 +170,8 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           VERSION="${VERSION:-unknown}"
-          curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+          # Mask webhook URL in any error output
+          curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H "Content-Type: application/json" \
             -d "{
               \"blocks\": [

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -1,0 +1,198 @@
+name: Deploy Proxy to Cloudflare
+
+on:
+  workflow_dispatch:
+    inputs:
+      skip_verification:
+        description: 'Skip post-deployment verification tests'
+        required: false
+        default: 'false'
+        type: boolean
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # Only allow deployment from production branch
+    if: github.ref == 'refs/heads/production'
+
+    steps:
+      - name: Checkout production branch
+        uses: actions/checkout@v4
+        with:
+          ref: production
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: proxy/package-lock.json
+
+      - name: Install dependencies
+        run: cd proxy && npm ci
+
+      - name: Get proxy version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./proxy/package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Deploying proxy version: $VERSION"
+
+      - name: Deploy to Cloudflare Workers
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          cd proxy
+          npx wrangler deploy
+
+      - name: Set Cloudflare secrets
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          cd proxy
+          echo "Setting CLIENT_ID..."
+          echo "${{ secrets.VITE_EEN_CLIENT_ID }}" | npx wrangler secret put CLIENT_ID
+
+          echo "Setting CLIENT_SECRET..."
+          echo "${{ secrets.EEN_CLIENT_SECRET }}" | npx wrangler secret put CLIENT_SECRET
+
+          echo "Setting ADMIN_EMAILS..."
+          echo "klaus+developer@klaushofrichter.net,khofrichter+lda@een.com" | npx wrangler secret put ADMIN_EMAILS
+
+          echo "Setting ALLOWED_ORIGINS..."
+          echo "https://klaushofrichter.github.io,http://127.0.0.1:3333" | npx wrangler secret put ALLOWED_ORIGINS
+
+          echo "Setting ALLOWED_API_DOMAINS..."
+          echo "eagleeyenetworks.com" | npx wrangler secret put ALLOWED_API_DOMAINS
+
+          echo "Setting REFRESH_TOKEN_TTL..."
+          echo "86400" | npx wrangler secret put REFRESH_TOKEN_TTL
+
+      - name: Store deploy version in KV
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          cd proxy
+          DEPLOY_TIME=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+          VERSION_STRING="een-oauth-proxy - ${{ steps.version.outputs.version }} - $DEPLOY_TIME"
+          NAMESPACE_ID=$(grep 'id = "' wrangler.toml | head -1 | sed 's/.*id = "\([^"]*\)".*/\1/')
+          echo "Storing version: $VERSION_STRING"
+          npx wrangler kv key put DEPLOY_VERSION "$VERSION_STRING" --namespace-id="$NAMESPACE_ID" --remote
+
+      - name: Wait for deployment propagation
+        run: |
+          echo "Waiting 10 seconds for deployment to propagate..."
+          sleep 10
+
+      - name: Verify deployment
+        if: ${{ inputs.skip_verification != 'true' }}
+        run: |
+          echo "Running production verification tests..."
+          BRIEF=1 ./scripts/test-production-proxy.sh
+
+      - name: Deployment summary
+        run: |
+          echo "## Proxy Deployment Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Worker:** een-oauth-proxy" >> $GITHUB_STEP_SUMMARY
+          echo "**URL:** https://een-oauth-proxy.klaushofrichter.workers.dev" >> $GITHUB_STEP_SUMMARY
+
+      - name: Notify Slack on success
+        if: success()
+        run: |
+          curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Proxy Deployed to Cloudflare",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Version:*\n${{ steps.version.outputs.version }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Status:*\n:white_check_mark: Success"
+                    }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "Health Check"
+                      },
+                      "url": "https://een-oauth-proxy.klaushofrichter.workers.dev/health"
+                    },
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Workflow"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }'
+
+      - name: Notify Slack on failure
+        if: failure()
+        run: |
+          curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Proxy Deployment Failed",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Version:*\n${{ steps.version.outputs.version }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Status:*\n:x: Failed"
+                    }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Workflow"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }'

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -59,16 +59,16 @@ jobs:
           echo "${{ secrets.EEN_CLIENT_SECRET }}" | npx wrangler secret put CLIENT_SECRET
 
           echo "Setting ADMIN_EMAILS..."
-          echo "klaus+developer@klaushofrichter.net,khofrichter+lda@een.com" | npx wrangler secret put ADMIN_EMAILS
+          echo "${{ secrets.ADMIN_EMAILS }}" | npx wrangler secret put ADMIN_EMAILS
 
           echo "Setting ALLOWED_ORIGINS..."
-          echo "https://klaushofrichter.github.io,http://127.0.0.1:3333" | npx wrangler secret put ALLOWED_ORIGINS
+          echo "${{ secrets.ALLOWED_ORIGINS }}" | npx wrangler secret put ALLOWED_ORIGINS
 
           echo "Setting ALLOWED_API_DOMAINS..."
-          echo "eagleeyenetworks.com" | npx wrangler secret put ALLOWED_API_DOMAINS
+          echo "${{ secrets.ALLOWED_API_DOMAINS }}" | npx wrangler secret put ALLOWED_API_DOMAINS
 
           echo "Setting REFRESH_TOKEN_TTL..."
-          echo "86400" | npx wrangler secret put REFRESH_TOKEN_TTL
+          echo "${{ secrets.REFRESH_TOKEN_TTL }}" | npx wrangler secret put REFRESH_TOKEN_TTL
 
       - name: Store deploy version in KV
         env:
@@ -78,7 +78,8 @@ jobs:
           cd proxy
           DEPLOY_TIME=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
           VERSION_STRING="een-oauth-proxy - ${{ steps.version.outputs.version }} - $DEPLOY_TIME"
-          NAMESPACE_ID=$(grep 'id = "' wrangler.toml | head -1 | sed 's/.*id = "\([^"]*\)".*/\1/')
+          # Get namespace ID using wrangler CLI
+          NAMESPACE_ID=$(npx wrangler kv namespace list --json | jq -r '.[] | select(.title | contains("EEN_OAUTH_SESSIONS")) | .id')
           echo "Storing version: $VERSION_STRING"
           npx wrangler kv key put DEPLOY_VERSION "$VERSION_STRING" --namespace-id="$NAMESPACE_ID" --remote
 
@@ -90,6 +91,9 @@ jobs:
       - name: Verify deployment
         if: ${{ inputs.skip_verification != 'true' }}
         run: |
+          # Verify curl and jq are available (pre-installed on Ubuntu runners)
+          command -v curl >/dev/null 2>&1 || { echo "curl is required but not installed"; exit 1; }
+          command -v jq >/dev/null 2>&1 || { echo "jq is required but not installed"; exit 1; }
           echo "Running production verification tests..."
           BRIEF=1 ./scripts/test-production-proxy.sh
 
@@ -103,6 +107,7 @@ jobs:
 
       - name: Notify Slack on success
         if: success()
+        continue-on-error: true
         run: |
           curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H "Content-Type: application/json" \
@@ -155,6 +160,7 @@ jobs:
 
       - name: Notify Slack on failure
         if: failure()
+        continue-on-error: true
         run: |
           curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H "Content-Type: application/json" \

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -80,6 +80,11 @@ jobs:
           VERSION_STRING="een-oauth-proxy - ${{ steps.version.outputs.version }} - $DEPLOY_TIME"
           # Get namespace ID using wrangler CLI
           NAMESPACE_ID=$(npx wrangler kv namespace list --json | jq -r '.[] | select(.title | contains("EEN_OAUTH_SESSIONS")) | .id')
+          # Validate namespace ID was found
+          if [ -z "$NAMESPACE_ID" ]; then
+            echo "Error: Could not find KV namespace EEN_OAUTH_SESSIONS"
+            exit 1
+          fi
           echo "Storing version: $VERSION_STRING"
           npx wrangler kv key put DEPLOY_VERSION "$VERSION_STRING" --namespace-id="$NAMESPACE_ID" --remote
 
@@ -162,43 +167,45 @@ jobs:
         if: failure()
         continue-on-error: true
         run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          VERSION="${VERSION:-unknown}"
           curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H "Content-Type: application/json" \
-            -d '{
-              "blocks": [
+            -d "{
+              \"blocks\": [
                 {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "Proxy Deployment Failed",
-                    "emoji": true
+                  \"type\": \"header\",
+                  \"text\": {
+                    \"type\": \"plain_text\",
+                    \"text\": \"Proxy Deployment Failed\",
+                    \"emoji\": true
                   }
                 },
                 {
-                  "type": "section",
-                  "fields": [
+                  \"type\": \"section\",
+                  \"fields\": [
                     {
-                      "type": "mrkdwn",
-                      "text": "*Version:*\n${{ steps.version.outputs.version }}"
+                      \"type\": \"mrkdwn\",
+                      \"text\": \"*Version:*\n${VERSION}\"
                     },
                     {
-                      "type": "mrkdwn",
-                      "text": "*Status:*\n:x: Failed"
+                      \"type\": \"mrkdwn\",
+                      \"text\": \"*Status:*\n:x: Failed\"
                     }
                   ]
                 },
                 {
-                  "type": "actions",
-                  "elements": [
+                  \"type\": \"actions\",
+                  \"elements\": [
                     {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "View Workflow"
+                      \"type\": \"button\",
+                      \"text\": {
+                        \"type\": \"plain_text\",
+                        \"text\": \"View Workflow\"
                       },
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                      \"url\": \"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"
                     }
                   ]
                 }
               ]
-            }'
+            }"

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -113,9 +113,11 @@ jobs:
       - name: Notify Slack on success
         if: success()
         continue-on-error: true
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: |
-          # Mask webhook URL in any error output
-          curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+          # Use env var to prevent webhook URL exposure in error output
+          curl -sf -X POST "$SLACK_WEBHOOK" \
             -H "Content-Type: application/json" \
             -d '{
               "blocks": [
@@ -167,11 +169,13 @@ jobs:
       - name: Notify Slack on failure
         if: failure()
         continue-on-error: true
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           VERSION="${VERSION:-unknown}"
-          # Mask webhook URL in any error output
-          curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+          # Use env var to prevent webhook URL exposure in error output
+          curl -sf -X POST "$SLACK_WEBHOOK" \
             -H "Content-Type: application/json" \
             -d "{
               \"blocks\": [

--- a/README.md
+++ b/README.md
@@ -549,8 +549,12 @@ Configure these secrets in your repository settings (Settings > Secrets and vari
 |--------|-------------|---------|
 | `CLOUDFLARE_API_TOKEN` | Cloudflare API token for Workers deployment (see below) | Proxy deployment workflow |
 | `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID (from dashboard URL) | Proxy deployment workflow |
-| `VITE_EEN_CLIENT_ID` | EEN OAuth Client ID | PR tests, deployment |
-| `EEN_CLIENT_SECRET` | EEN OAuth Client Secret | PR tests (local proxy) |
+| `VITE_EEN_CLIENT_ID` | EEN OAuth Client ID | PR tests, proxy deployment |
+| `EEN_CLIENT_SECRET` | EEN OAuth Client Secret | PR tests, proxy deployment |
+| `ADMIN_EMAILS` | Comma-separated admin email addresses | Proxy deployment |
+| `ALLOWED_ORIGINS` | Comma-separated CORS allowed origins | Proxy deployment |
+| `ALLOWED_API_DOMAINS` | Comma-separated allowed API domains for SSRF protection | Proxy deployment |
+| `REFRESH_TOKEN_TTL` | Session TTL in seconds (default: 86400) | Proxy deployment |
 | `ADMIN_TEST_USER` | Test admin user email (must be in ADMIN_EMAILS) | Playwright tests |
 | `ADMIN_TEST_PASSWORD` | Test admin user password | Playwright tests |
 | `TEST_USER` | Test user email (must not be in ADMIN_EMAILS) | Playwright tests |

--- a/README.md
+++ b/README.md
@@ -547,6 +547,8 @@ Configure these secrets in your repository settings (Settings > Secrets and vari
 
 | Secret | Description | Used By |
 |--------|-------------|---------|
+| `CLOUDFLARE_API_TOKEN` | Cloudflare API token for Workers deployment (see below) | Proxy deployment workflow |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID (from dashboard URL) | Proxy deployment workflow |
 | `VITE_EEN_CLIENT_ID` | EEN OAuth Client ID | PR tests, deployment |
 | `EEN_CLIENT_SECRET` | EEN OAuth Client Secret | PR tests (local proxy) |
 | `ADMIN_TEST_USER` | Test admin user email (must be in ADMIN_EMAILS) | Playwright tests |
@@ -556,6 +558,35 @@ Configure these secrets in your repository settings (Settings > Secrets and vari
 | `ANTHROPIC_API_KEY` | Anthropic API key for Claude Code reviews | Claude PR review workflow |
 | `GEMINI_API_KEY` | Google Gemini API key for security reviews | Gemini PR review workflow |
 | `SLACK_WEBHOOK` | Slack incoming webhook URL for notifications | Deploy and release workflows |
+
+**Cloudflare API Token:**
+
+To create a Cloudflare API token for automated proxy deployment:
+
+1. Go to [Cloudflare Dashboard](https://dash.cloudflare.com) → Profile → API Tokens
+2. Click "Create Token"
+3. Use the "Edit Cloudflare Workers" template or create a custom token with:
+   - Account → Workers Scripts → Edit
+   - Account → Workers KV Storage → Edit
+4. Scope the token to your account
+5. Copy the token value for `CLOUDFLARE_API_TOKEN`
+
+The `CLOUDFLARE_ACCOUNT_ID` can be found in your Cloudflare dashboard URL:
+`https://dash.cloudflare.com/<ACCOUNT_ID>/workers/...`
+
+**Upload Secrets Script:**
+
+A convenience script is provided to upload all secrets from your local `proxy/.env` file to GitHub:
+
+```bash
+./scripts/upload-github-secrets.sh
+```
+
+This script reads secrets from `proxy/.env` and uploads them to GitHub using the `gh` CLI. It handles the name mapping between local environment variables and GitHub secret names (e.g., `CLIENT_ID` → `VITE_EEN_CLIENT_ID`).
+
+Requirements:
+- GitHub CLI (`gh`) must be installed and authenticated
+- `proxy/.env` must contain the required secrets
 
 ### Required GitHub Variables
 

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.32",
+  "version": "1.2.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.2.32",
+      "version": "1.2.33",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.32",
+  "version": "1.2.33",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -164,7 +164,11 @@ function isValidEenUrl(url, env) {
     } else {
       // Parse and cache the allowlist
       // Limit config string length to prevent DoS via large config
-      const allowedDomainsStr = rawAllowedDomains.length > MAX_ALLOWED_DOMAINS_CONFIG_LENGTH
+      const wasTruncated = rawAllowedDomains.length > MAX_ALLOWED_DOMAINS_CONFIG_LENGTH
+      if (wasTruncated) {
+        debugLog(env, `[WARNING] ALLOWED_API_DOMAINS truncated from ${rawAllowedDomains.length} to ${MAX_ALLOWED_DOMAINS_CONFIG_LENGTH} chars`)
+      }
+      const allowedDomainsStr = wasTruncated
         ? rawAllowedDomains.substring(0, MAX_ALLOWED_DOMAINS_CONFIG_LENGTH)
         : rawAllowedDomains
       allowedDomains = allowedDomainsStr

--- a/scripts/upload-github-secrets.sh
+++ b/scripts/upload-github-secrets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Upload secrets from proxy/.env to GitHub repository secrets
 #
@@ -86,6 +86,13 @@ echo ""
 echo "--- API Keys ---"
 upload_secret "ANTHROPIC_API_KEY" "ANTHROPIC_API_KEY"
 upload_secret "GEMINI_API_KEY" "GEMINI_API_KEY"
+
+echo ""
+echo "--- Proxy Configuration ---"
+upload_secret "ADMIN_EMAILS" "ADMIN_EMAILS"
+upload_secret "ALLOWED_ORIGINS" "ALLOWED_ORIGINS"
+upload_secret "ALLOWED_API_DOMAINS" "ALLOWED_API_DOMAINS"
+upload_secret "REFRESH_TOKEN_TTL" "REFRESH_TOKEN_TTL"
 
 echo ""
 echo "--- Notifications ---"

--- a/scripts/upload-github-secrets.sh
+++ b/scripts/upload-github-secrets.sh
@@ -96,6 +96,8 @@ echo ""
 echo "--- Test Credentials ---"
 upload_secret "TEST_USER" "TEST_USER"
 upload_secret "TEST_PASSWORD" "TEST_PASSWORD"
+# ADMIN_TEST_USER/PASSWORD intentionally use the same credentials as TEST_USER/PASSWORD
+# The test user must be in ADMIN_EMAILS to have admin access for admin app tests
 upload_secret "ADMIN_TEST_USER" "TEST_USER"
 upload_secret "ADMIN_TEST_PASSWORD" "TEST_PASSWORD"
 

--- a/scripts/upload-github-secrets.sh
+++ b/scripts/upload-github-secrets.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+#
+# Upload secrets from proxy/.env to GitHub repository secrets
+#
+# Usage: ./scripts/upload-github-secrets.sh
+#
+# Requires: GitHub CLI (gh) authenticated with repo access
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+ENV_FILE="$PROJECT_ROOT/proxy/.env"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo "=========================================="
+echo "Upload Secrets to GitHub Repository"
+echo "=========================================="
+
+# Check gh CLI is installed and authenticated
+if ! command -v gh &> /dev/null; then
+    echo -e "${RED}Error: GitHub CLI (gh) is not installed${NC}"
+    exit 1
+fi
+
+if ! gh auth status &> /dev/null; then
+    echo -e "${RED}Error: GitHub CLI is not authenticated. Run 'gh auth login' first.${NC}"
+    exit 1
+fi
+
+# Check .env file exists
+if [ ! -f "$ENV_FILE" ]; then
+    echo -e "${RED}Error: $ENV_FILE not found${NC}"
+    exit 1
+fi
+
+echo "Reading secrets from: $ENV_FILE"
+echo ""
+
+# Function to upload a secret
+upload_secret() {
+    local gh_secret_name="$1"
+    local env_var_name="$2"
+
+    # Extract value from .env file (handles both quoted and unquoted values)
+    local value=$(grep "^${env_var_name}=" "$ENV_FILE" | cut -d'=' -f2- | sed 's/^"//' | sed 's/"$//')
+
+    if [ -z "$value" ]; then
+        echo -e "${YELLOW}⚠ Skipping $gh_secret_name - $env_var_name not found in .env${NC}"
+        return
+    fi
+
+    echo -n "Uploading $gh_secret_name... "
+    if echo "$value" | gh secret set "$gh_secret_name" 2>/dev/null; then
+        echo -e "${GREEN}✓${NC}"
+    else
+        echo -e "${RED}✗ Failed${NC}"
+        return 1
+    fi
+}
+
+# Upload Cloudflare secrets (new)
+echo "--- Cloudflare Deployment Secrets ---"
+upload_secret "CLOUDFLARE_API_TOKEN" "CLOUDFLARE_API_TOKEN"
+upload_secret "CLOUDFLARE_ACCOUNT_ID" "CLOUDFLARE_ACCOUNT_ID"
+
+echo ""
+echo "--- OAuth Secrets (mapped names) ---"
+upload_secret "VITE_EEN_CLIENT_ID" "CLIENT_ID"
+upload_secret "EEN_CLIENT_SECRET" "CLIENT_SECRET"
+
+echo ""
+echo "--- Test Credentials ---"
+upload_secret "TEST_USER" "TEST_USER"
+upload_secret "TEST_PASSWORD" "TEST_PASSWORD"
+upload_secret "ADMIN_TEST_USER" "TEST_USER"
+upload_secret "ADMIN_TEST_PASSWORD" "TEST_PASSWORD"
+
+echo ""
+echo "--- API Keys ---"
+upload_secret "ANTHROPIC_API_KEY" "ANTHROPIC_API_KEY"
+upload_secret "GEMINI_API_KEY" "GEMINI_API_KEY"
+
+echo ""
+echo "--- Notifications ---"
+upload_secret "SLACK_WEBHOOK" "SLACK_WEBHOOK"
+
+echo ""
+echo "=========================================="
+echo -e "${GREEN}Secret upload complete!${NC}"
+echo "=========================================="
+echo ""
+echo "Verify with: gh secret list"

--- a/scripts/upload-github-secrets.sh
+++ b/scripts/upload-github-secrets.sh
@@ -49,11 +49,28 @@ upload_secret() {
     local env_var_name="$2"
 
     # Extract value from .env file (handles both quoted and unquoted values)
-    local value=$(grep "^${env_var_name}=" "$ENV_FILE" | cut -d'=' -f2- | sed 's/^"//' | sed 's/"$//')
+    # Uses cut -d'=' -f2- to handle values containing '=' characters
+    local line=$(grep "^${env_var_name}=" "$ENV_FILE" 2>/dev/null | head -1)
 
-    if [ -z "$value" ]; then
+    if [ -z "$line" ]; then
         echo -e "${YELLOW}⚠ Skipping $gh_secret_name - $env_var_name not found in .env${NC}"
         return
+    fi
+
+    # Extract value after first '=' and strip surrounding quotes
+    local value="${line#*=}"
+    value="${value#\"}"
+    value="${value%\"}"
+
+    if [ -z "$value" ]; then
+        echo -e "${YELLOW}⚠ Skipping $gh_secret_name - $env_var_name has empty value${NC}"
+        return
+    fi
+
+    # Warn if value contains newlines (not supported)
+    if [[ "$value" == *$'\n'* ]]; then
+        echo -e "${RED}✗ $gh_secret_name contains newlines (not supported)${NC}"
+        return 1
     fi
 
     echo -n "Uploading $gh_secret_name... "


### PR DESCRIPTION
## Summary
- Add `deploy-proxy.yml` workflow for automated Cloudflare Workers deployment
- Add `upload-github-secrets.sh` script to upload secrets from `proxy/.env` to GitHub
- Document new `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` secrets in README

## Details

**Deployment Workflow:**
- Manual trigger only (`workflow_dispatch`) for initial testing
- Deploys from production branch only
- Sets all Cloudflare secrets (CLIENT_ID, CLIENT_SECRET, ADMIN_EMAILS, etc.)
- Stores deploy version in KV
- Runs verification tests after deployment
- Sends Slack notifications on success/failure

**Secrets Upload Script:**
- Reads secrets from `proxy/.env`
- Uploads to GitHub using `gh` CLI
- Handles name mapping (e.g., `CLIENT_ID` → `VITE_EEN_CLIENT_ID`)

## Test plan
- [ ] Merge PR to production
- [ ] Trigger deploy-proxy workflow manually from Actions tab
- [ ] Verify deployment completes successfully
- [ ] Check Slack notification received
- [ ] Verify proxy health endpoint responds with new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)