### PR TITLE
Fix KV namespace ID extraction in deploy workflow

### DIFF
--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -78,8 +78,8 @@ jobs:
           cd proxy
           DEPLOY_TIME=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
           VERSION_STRING="een-oauth-proxy - ${{ steps.version.outputs.version }} - $DEPLOY_TIME"
-          # Get namespace ID using wrangler CLI (exact match on title)
-          NAMESPACE_ID=$(npx wrangler kv namespace list --json | jq -r '.[] | select(.title == "een-oauth-proxy-EEN_OAUTH_SESSIONS") | .id')
+          # Get namespace ID from wrangler.toml
+          NAMESPACE_ID=$(grep 'id = "' wrangler.toml | head -1 | sed 's/.*id = "\([^"]*\)".*/\1/')
           # Validate namespace ID was found
           if [ -z "$NAMESPACE_ID" ]; then
             echo "Error: Could not find KV namespace EEN_OAUTH_SESSIONS"


### PR DESCRIPTION
## Summary
- Fix wrangler CLI `--json` flag not supported error in deploy workflow
- Use grep/sed to read namespace ID from wrangler.toml instead

## Details
The `wrangler kv namespace list --json` command failed with "Unknown argument: json" error. 
This fix reads the namespace ID directly from wrangler.toml which is more reliable.

## Test plan
- [ ] Merge PR
- [ ] Re-trigger deploy-proxy workflow
- [ ] Verify deployment succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)