### PR TITLE
Add automatic proxy deployment with rollback and documentation updates

### DIFF
--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -94,10 +94,15 @@ jobs:
           cd proxy
           # Get the current active version ID before deploying
           VERSION_ID=$(npx wrangler versions list 2>/dev/null | grep -E '^\S+' | head -1 | awk '{print $1}' || echo "")
-          if [ -n "$VERSION_ID" ]; then
+          # Validate version ID format (UUID-like: alphanumeric with hyphens)
+          if [ -n "$VERSION_ID" ] && [[ "$VERSION_ID" =~ ^[a-f0-9-]+$ ]]; then
             echo "Current version ID: $VERSION_ID"
             echo "version_id=$VERSION_ID" >> $GITHUB_OUTPUT
             echo "has_previous_version=true" >> $GITHUB_OUTPUT
+          elif [ -n "$VERSION_ID" ]; then
+            echo "::warning::Version ID '$VERSION_ID' does not match expected format, ignoring"
+            echo "version_id=" >> $GITHUB_OUTPUT
+            echo "has_previous_version=false" >> $GITHUB_OUTPUT
           else
             echo "::notice::No previous version found (this may be first deployment)"
             echo "version_id=" >> $GITHUB_OUTPUT
@@ -148,11 +153,14 @@ jobs:
           cd proxy
           DEPLOY_TIME=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
           VERSION_STRING="een-oauth-proxy - ${{ steps.version.outputs.version }} - $DEPLOY_TIME"
-          # Get namespace ID from wrangler.toml
-          NAMESPACE_ID=$(grep 'id = "' wrangler.toml | head -1 | sed 's/.*id = "\([^"]*\)".*/\1/')
-          # Validate namespace ID was found
+          # Get namespace ID from wrangler.toml (look for id after kv_namespaces section)
+          NAMESPACE_ID=$(awk '/\[\[kv_namespaces\]\]/,/^$/' wrangler.toml | grep 'id = "' | head -1 | sed 's/.*id = "\([^"]*\)".*/\1/')
+          # Validate namespace ID was found and has correct format (32-char hex)
           if [ -z "$NAMESPACE_ID" ]; then
-            echo "Error: Could not find KV namespace EEN_OAUTH_SESSIONS"
+            echo "::error::Could not find KV namespace ID in wrangler.toml"
+            exit 1
+          elif ! [[ "$NAMESPACE_ID" =~ ^[a-f0-9]{32}$ ]]; then
+            echo "::error::KV namespace ID '$NAMESPACE_ID' does not match expected format (32-char hex)"
             exit 1
           fi
           echo "Storing version: $VERSION_STRING"
@@ -177,7 +185,7 @@ jobs:
           BRIEF=1 ./scripts/test-production-proxy.sh
 
       - name: Rollback on verification failure
-        if: failure() && steps.store_version.outputs.deployment_complete == 'true' && steps.current_deployment.outputs.has_previous_version == 'true'
+        if: failure() && steps.verify.outcome == 'failure' && steps.store_version.outputs.deployment_complete == 'true' && steps.current_deployment.outputs.has_previous_version == 'true'
         id: rollback
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -204,7 +212,7 @@ jobs:
           echo "Verification tests failed. Rolled back to version: \`$ROLLBACK_VERSION\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Rollback not possible (no previous version)
-        if: failure() && steps.store_version.outputs.deployment_complete == 'true' && steps.current_deployment.outputs.has_previous_version != 'true'
+        if: failure() && steps.verify.outcome == 'failure' && steps.store_version.outputs.deployment_complete == 'true' && steps.current_deployment.outputs.has_previous_version != 'true'
         run: |
           echo "::error::Verification failed but rollback not possible - no previous version exists"
           echo "## Rollback Not Possible" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -184,8 +184,29 @@ jobs:
           echo "Running production verification tests..."
           BRIEF=1 ./scripts/test-production-proxy.sh
 
+      - name: Check rollback conditions
+        if: always() && steps.check.outputs.should_deploy == 'true'
+        id: rollback_check
+        run: |
+          # Determine if rollback should be attempted (simplifies subsequent conditions)
+          VERIFICATION_FAILED="${{ steps.verify.outcome == 'failure' }}"
+          DEPLOYMENT_COMPLETE="${{ steps.store_version.outputs.deployment_complete == 'true' }}"
+          HAS_PREVIOUS="${{ steps.current_deployment.outputs.has_previous_version == 'true' }}"
+
+          if [ "$VERIFICATION_FAILED" = "true" ] && [ "$DEPLOYMENT_COMPLETE" = "true" ]; then
+            echo "should_rollback=true" >> $GITHUB_OUTPUT
+            if [ "$HAS_PREVIOUS" = "true" ]; then
+              echo "can_rollback=true" >> $GITHUB_OUTPUT
+            else
+              echo "can_rollback=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "should_rollback=false" >> $GITHUB_OUTPUT
+            echo "can_rollback=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Rollback on verification failure
-        if: failure() && steps.verify.outcome == 'failure' && steps.store_version.outputs.deployment_complete == 'true' && steps.current_deployment.outputs.has_previous_version == 'true'
+        if: failure() && steps.rollback_check.outputs.should_rollback == 'true' && steps.rollback_check.outputs.can_rollback == 'true'
         id: rollback
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -212,7 +233,7 @@ jobs:
           echo "Verification tests failed. Rolled back to version: \`$ROLLBACK_VERSION\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Rollback not possible (no previous version)
-        if: failure() && steps.verify.outcome == 'failure' && steps.store_version.outputs.deployment_complete == 'true' && steps.current_deployment.outputs.has_previous_version != 'true'
+        if: failure() && steps.rollback_check.outputs.should_rollback == 'true' && steps.rollback_check.outputs.can_rollback == 'false'
         run: |
           echo "::error::Verification failed but rollback not possible - no previous version exists"
           echo "## Rollback Not Possible" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -9,13 +9,16 @@ on:
         default: 'false'
         type: boolean
       force_deploy:
-        description: 'Deploy even if versions match'
+        description: 'Deploy even if versions match (use with caution)'
         required: false
         default: 'false'
         type: boolean
   push:
     branches: [production]
     paths: ['proxy/**']
+
+env:
+  PROXY_URL: https://een-oauth-proxy.klaushofrichter.workers.dev
 
 jobs:
   deploy:
@@ -49,7 +52,8 @@ jobs:
       - name: Get deployed version
         id: deployed
         run: |
-          DEPLOYED=$(curl -sf https://een-oauth-proxy.klaushofrichter.workers.dev/health | jq -r '.version' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+          # Extract version, handling semver with pre-release tags (e.g., 1.0.0-beta.1)
+          DEPLOYED=$(curl -sf "$PROXY_URL/health" | jq -r '.version' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?' || echo "unknown")
           echo "deployed_version=$DEPLOYED" >> $GITHUB_OUTPUT
           echo "Deployed version: $DEPLOYED"
 
@@ -61,7 +65,7 @@ jobs:
           FORCE_DEPLOY="${{ inputs.force_deploy }}"
 
           if [ "$FORCE_DEPLOY" = "true" ]; then
-            echo "Force deploy requested"
+            echo "::warning::Force deploy requested - bypassing version check"
             echo "should_deploy=true" >> $GITHUB_OUTPUT
           elif [ "$PACKAGE_VERSION" != "$DEPLOYED_VERSION" ]; then
             echo "Version mismatch: $PACKAGE_VERSION != $DEPLOYED_VERSION"
@@ -78,7 +82,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Package version (${{ steps.version.outputs.version }}) matches deployed version (${{ steps.deployed.outputs.deployed_version }})." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Use **force_deploy** input to deploy anyway." >> $GITHUB_STEP_SUMMARY
+          echo "Use **force_deploy** input to deploy anyway (use with caution)." >> $GITHUB_STEP_SUMMARY
 
       - name: Get current deployment version ID (for rollback)
         if: steps.check.outputs.should_deploy == 'true'
@@ -93,21 +97,21 @@ jobs:
           if [ -n "$VERSION_ID" ]; then
             echo "Current version ID: $VERSION_ID"
             echo "version_id=$VERSION_ID" >> $GITHUB_OUTPUT
+            echo "has_previous_version=true" >> $GITHUB_OUTPUT
           else
-            echo "Could not determine current version ID (this may be first deployment)"
+            echo "::notice::No previous version found (this may be first deployment)"
             echo "version_id=" >> $GITHUB_OUTPUT
+            echo "has_previous_version=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Deploy to Cloudflare Workers
         if: steps.check.outputs.should_deploy == 'true'
-        id: deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           cd proxy
           npx wrangler deploy
-          echo "deployed=true" >> $GITHUB_OUTPUT
 
       - name: Set Cloudflare secrets
         if: steps.check.outputs.should_deploy == 'true'
@@ -117,25 +121,26 @@ jobs:
         run: |
           cd proxy
           echo "Setting CLIENT_ID..."
-          echo "${{ secrets.VITE_EEN_CLIENT_ID }}" | npx wrangler secret put CLIENT_ID
+          printf '%s' "${{ secrets.VITE_EEN_CLIENT_ID }}" | npx wrangler secret put CLIENT_ID
 
           echo "Setting CLIENT_SECRET..."
-          echo "${{ secrets.EEN_CLIENT_SECRET }}" | npx wrangler secret put CLIENT_SECRET
+          printf '%s' "${{ secrets.EEN_CLIENT_SECRET }}" | npx wrangler secret put CLIENT_SECRET
 
           echo "Setting ADMIN_EMAILS..."
-          echo "${{ secrets.ADMIN_EMAILS }}" | npx wrangler secret put ADMIN_EMAILS
+          printf '%s' "${{ secrets.ADMIN_EMAILS }}" | npx wrangler secret put ADMIN_EMAILS
 
           echo "Setting ALLOWED_ORIGINS..."
-          echo "${{ secrets.ALLOWED_ORIGINS }}" | npx wrangler secret put ALLOWED_ORIGINS
+          printf '%s' "${{ secrets.ALLOWED_ORIGINS }}" | npx wrangler secret put ALLOWED_ORIGINS
 
           echo "Setting ALLOWED_API_DOMAINS..."
-          echo "${{ secrets.ALLOWED_API_DOMAINS }}" | npx wrangler secret put ALLOWED_API_DOMAINS
+          printf '%s' "${{ secrets.ALLOWED_API_DOMAINS }}" | npx wrangler secret put ALLOWED_API_DOMAINS
 
           echo "Setting REFRESH_TOKEN_TTL..."
-          echo "${{ secrets.REFRESH_TOKEN_TTL }}" | npx wrangler secret put REFRESH_TOKEN_TTL
+          printf '%s' "${{ secrets.REFRESH_TOKEN_TTL }}" | npx wrangler secret put REFRESH_TOKEN_TTL
 
       - name: Store deploy version in KV
         if: steps.check.outputs.should_deploy == 'true'
+        id: store_version
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -152,12 +157,14 @@ jobs:
           fi
           echo "Storing version: $VERSION_STRING"
           npx wrangler kv key put DEPLOY_VERSION "$VERSION_STRING" --namespace-id="$NAMESPACE_ID" --remote
+          # Mark deployment as fully complete (after secrets and KV are set)
+          echo "deployment_complete=true" >> $GITHUB_OUTPUT
 
       - name: Wait for deployment propagation
         if: steps.check.outputs.should_deploy == 'true'
         run: |
-          echo "Waiting 10 seconds for deployment to propagate..."
-          sleep 10
+          echo "Waiting 15 seconds for deployment to propagate..."
+          sleep 15
 
       - name: Verify deployment
         if: steps.check.outputs.should_deploy == 'true' && inputs.skip_verification != 'true'
@@ -170,18 +177,40 @@ jobs:
           BRIEF=1 ./scripts/test-production-proxy.sh
 
       - name: Rollback on verification failure
-        if: failure() && steps.deploy.outputs.deployed == 'true' && steps.current_deployment.outputs.version_id != ''
+        if: failure() && steps.store_version.outputs.deployment_complete == 'true' && steps.current_deployment.outputs.has_previous_version == 'true'
+        id: rollback
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           cd proxy
           ROLLBACK_VERSION="${{ steps.current_deployment.outputs.version_id }}"
-          echo "::warning::Verification failed! Rolling back to version: $ROLLBACK_VERSION"
+          echo "::error::Verification failed! Rolling back to version: $ROLLBACK_VERSION"
           npx wrangler versions deploy "$ROLLBACK_VERSION" --yes
+          echo "rollback_performed=true" >> $GITHUB_OUTPUT
+
+          # Verify rollback was successful
+          echo "Waiting 10 seconds for rollback to propagate..."
+          sleep 10
+          echo "Verifying rollback health..."
+          if curl -sf "$PROXY_URL/health" | jq -e '.status == "ok"' > /dev/null; then
+            echo "::notice::Rollback verified - health check passed"
+          else
+            echo "::error::Rollback health check failed!"
+          fi
+
           echo "## Rollback Performed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Verification tests failed. Rolled back to version: $ROLLBACK_VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "Verification tests failed. Rolled back to version: \`$ROLLBACK_VERSION\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: Rollback not possible (no previous version)
+        if: failure() && steps.store_version.outputs.deployment_complete == 'true' && steps.current_deployment.outputs.has_previous_version != 'true'
+        run: |
+          echo "::error::Verification failed but rollback not possible - no previous version exists"
+          echo "## Rollback Not Possible" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Verification tests failed but no previous version exists to rollback to." >> $GITHUB_STEP_SUMMARY
+          echo "This may be the first deployment. Manual intervention required." >> $GITHUB_STEP_SUMMARY
 
       - name: Deployment summary
         if: steps.check.outputs.should_deploy == 'true' && success()
@@ -191,7 +220,7 @@ jobs:
           echo "**Version:** ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Previous:** ${{ steps.deployed.outputs.deployed_version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Worker:** een-oauth-proxy" >> $GITHUB_STEP_SUMMARY
-          echo "**URL:** https://een-oauth-proxy.klaushofrichter.workers.dev" >> $GITHUB_STEP_SUMMARY
+          echo "**URL:** $PROXY_URL" >> $GITHUB_STEP_SUMMARY
 
       - name: Notify Slack on success
         if: steps.check.outputs.should_deploy == 'true' && success()
@@ -234,7 +263,7 @@ jobs:
                         "type": "plain_text",
                         "text": "Health Check"
                       },
-                      "url": "https://een-oauth-proxy.klaushofrichter.workers.dev/health"
+                      "url": "'"$PROXY_URL"'/health"
                     },
                     {
                       "type": "button",
@@ -257,9 +286,11 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           VERSION="${VERSION:-unknown}"
-          ROLLBACK_MSG=""
-          if [ -n "${{ steps.current_deployment.outputs.version_id }}" ]; then
-            ROLLBACK_MSG=" (rolled back)"
+          ROLLBACK_STATUS=""
+          if [ "${{ steps.rollback.outputs.rollback_performed }}" = "true" ]; then
+            ROLLBACK_STATUS=" (rolled back to ${{ steps.current_deployment.outputs.version_id }})"
+          elif [ "${{ steps.current_deployment.outputs.has_previous_version }}" != "true" ]; then
+            ROLLBACK_STATUS=" (rollback not possible - no previous version)"
           fi
           # Use env var to prevent webhook URL exposure in error output
           curl -sf -X POST "$SLACK_WEBHOOK" \
@@ -270,7 +301,7 @@ jobs:
                   \"type\": \"header\",
                   \"text\": {
                     \"type\": \"plain_text\",
-                    \"text\": \"Proxy Deployment Failed${ROLLBACK_MSG}\",
+                    \"text\": \"Proxy Deployment Failed${ROLLBACK_STATUS}\",
                     \"emoji\": true
                   }
                 },

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -208,22 +208,31 @@ jobs:
         if: always() && steps.check.outputs.should_deploy == 'true'
         id: rollback_check
         run: |
-          # Determine if rollback should be attempted (simplifies subsequent conditions)
-          # Rollback if: verification failed, OR any post-deploy step failed while deploy succeeded
+          # Determine if rollback should be attempted
+          # Rollback triggers if: deploy succeeded but any subsequent step failed
+          # - verification failed, OR
+          # - secrets/KV steps failed (deployment_complete not set), OR
+          # - workflow is failing for any reason after deploy
           DEPLOY_SUCCEEDED="${{ steps.deploy.outputs.deployed == 'true' }}"
-          VERIFICATION_FAILED="${{ steps.verify.outcome == 'failure' }}"
-          SECRETS_FAILED="${{ steps.deploy.outcome == 'success' && steps.store_version.outcome == 'failure' }}"
           DEPLOYMENT_COMPLETE="${{ steps.store_version.outputs.deployment_complete == 'true' }}"
           HAS_PREVIOUS="${{ steps.current_deployment.outputs.has_previous_version == 'true' }}"
+          WORKFLOW_FAILING="${{ failure() }}"
 
-          # Rollback needed if verification failed OR if deploy succeeded but secrets/KV failed
+          echo "Deploy succeeded: $DEPLOY_SUCCEEDED"
+          echo "Deployment complete: $DEPLOYMENT_COMPLETE"
+          echo "Has previous version: $HAS_PREVIOUS"
+          echo "Workflow failing: $WORKFLOW_FAILING"
+
+          # Rollback if deploy succeeded but workflow is failing OR deployment didn't complete
           if [ "$DEPLOY_SUCCEEDED" = "true" ]; then
-            if [ "$VERIFICATION_FAILED" = "true" ] || [ "$SECRETS_FAILED" = "true" ] || [ "$DEPLOYMENT_COMPLETE" != "true" ]; then
+            if [ "$WORKFLOW_FAILING" = "true" ] || [ "$DEPLOYMENT_COMPLETE" != "true" ]; then
               echo "should_rollback=true" >> $GITHUB_OUTPUT
               if [ "$HAS_PREVIOUS" = "true" ]; then
                 echo "can_rollback=true" >> $GITHUB_OUTPUT
+                echo "::notice::Rollback conditions met - will attempt rollback"
               else
                 echo "can_rollback=false" >> $GITHUB_OUTPUT
+                echo "::warning::Rollback needed but no previous version available"
               fi
               exit 0
             fi

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -8,6 +8,14 @@ on:
         required: false
         default: 'false'
         type: boolean
+      force_deploy:
+        description: 'Deploy even if versions match'
+        required: false
+        default: 'false'
+        type: boolean
+  push:
+    branches: [production]
+    paths: ['proxy/**']
 
 jobs:
   deploy:
@@ -31,22 +39,78 @@ jobs:
       - name: Install dependencies
         run: cd proxy && npm ci
 
-      - name: Get proxy version
+      - name: Get proxy version from package.json
         id: version
         run: |
           VERSION=$(node -p "require('./proxy/package.json').version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Deploying proxy version: $VERSION"
+          echo "Package version: $VERSION"
+
+      - name: Get deployed version
+        id: deployed
+        run: |
+          DEPLOYED=$(curl -sf https://een-oauth-proxy.klaushofrichter.workers.dev/health | jq -r '.version' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+          echo "deployed_version=$DEPLOYED" >> $GITHUB_OUTPUT
+          echo "Deployed version: $DEPLOYED"
+
+      - name: Check if deployment needed
+        id: check
+        run: |
+          PACKAGE_VERSION="${{ steps.version.outputs.version }}"
+          DEPLOYED_VERSION="${{ steps.deployed.outputs.deployed_version }}"
+          FORCE_DEPLOY="${{ inputs.force_deploy }}"
+
+          if [ "$FORCE_DEPLOY" = "true" ]; then
+            echo "Force deploy requested"
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+          elif [ "$PACKAGE_VERSION" != "$DEPLOYED_VERSION" ]; then
+            echo "Version mismatch: $PACKAGE_VERSION != $DEPLOYED_VERSION"
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+          else
+            echo "Versions match: $PACKAGE_VERSION = $DEPLOYED_VERSION"
+            echo "should_deploy=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Skip deployment (versions match)
+        if: steps.check.outputs.should_deploy == 'false'
+        run: |
+          echo "## Deployment Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Package version (${{ steps.version.outputs.version }}) matches deployed version (${{ steps.deployed.outputs.deployed_version }})." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Use **force_deploy** input to deploy anyway." >> $GITHUB_STEP_SUMMARY
+
+      - name: Get current deployment version ID (for rollback)
+        if: steps.check.outputs.should_deploy == 'true'
+        id: current_deployment
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          cd proxy
+          # Get the current active version ID before deploying
+          VERSION_ID=$(npx wrangler versions list 2>/dev/null | grep -E '^\S+' | head -1 | awk '{print $1}' || echo "")
+          if [ -n "$VERSION_ID" ]; then
+            echo "Current version ID: $VERSION_ID"
+            echo "version_id=$VERSION_ID" >> $GITHUB_OUTPUT
+          else
+            echo "Could not determine current version ID (this may be first deployment)"
+            echo "version_id=" >> $GITHUB_OUTPUT
+          fi
 
       - name: Deploy to Cloudflare Workers
+        if: steps.check.outputs.should_deploy == 'true'
+        id: deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           cd proxy
           npx wrangler deploy
+          echo "deployed=true" >> $GITHUB_OUTPUT
 
       - name: Set Cloudflare secrets
+        if: steps.check.outputs.should_deploy == 'true'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -71,6 +135,7 @@ jobs:
           echo "${{ secrets.REFRESH_TOKEN_TTL }}" | npx wrangler secret put REFRESH_TOKEN_TTL
 
       - name: Store deploy version in KV
+        if: steps.check.outputs.should_deploy == 'true'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -89,12 +154,14 @@ jobs:
           npx wrangler kv key put DEPLOY_VERSION "$VERSION_STRING" --namespace-id="$NAMESPACE_ID" --remote
 
       - name: Wait for deployment propagation
+        if: steps.check.outputs.should_deploy == 'true'
         run: |
           echo "Waiting 10 seconds for deployment to propagate..."
           sleep 10
 
       - name: Verify deployment
-        if: ${{ inputs.skip_verification != 'true' }}
+        if: steps.check.outputs.should_deploy == 'true' && inputs.skip_verification != 'true'
+        id: verify
         run: |
           # Verify curl and jq are available (pre-installed on Ubuntu runners)
           command -v curl >/dev/null 2>&1 || { echo "curl is required but not installed"; exit 1; }
@@ -102,16 +169,32 @@ jobs:
           echo "Running production verification tests..."
           BRIEF=1 ./scripts/test-production-proxy.sh
 
+      - name: Rollback on verification failure
+        if: failure() && steps.deploy.outputs.deployed == 'true' && steps.current_deployment.outputs.version_id != ''
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          cd proxy
+          ROLLBACK_VERSION="${{ steps.current_deployment.outputs.version_id }}"
+          echo "::warning::Verification failed! Rolling back to version: $ROLLBACK_VERSION"
+          npx wrangler versions deploy "$ROLLBACK_VERSION" --yes
+          echo "## Rollback Performed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Verification tests failed. Rolled back to version: $ROLLBACK_VERSION" >> $GITHUB_STEP_SUMMARY
+
       - name: Deployment summary
+        if: steps.check.outputs.should_deploy == 'true' && success()
         run: |
           echo "## Proxy Deployment Complete" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Previous:** ${{ steps.deployed.outputs.deployed_version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Worker:** een-oauth-proxy" >> $GITHUB_STEP_SUMMARY
           echo "**URL:** https://een-oauth-proxy.klaushofrichter.workers.dev" >> $GITHUB_STEP_SUMMARY
 
       - name: Notify Slack on success
-        if: success()
+        if: steps.check.outputs.should_deploy == 'true' && success()
         continue-on-error: true
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
@@ -174,6 +257,10 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           VERSION="${VERSION:-unknown}"
+          ROLLBACK_MSG=""
+          if [ -n "${{ steps.current_deployment.outputs.version_id }}" ]; then
+            ROLLBACK_MSG=" (rolled back)"
+          fi
           # Use env var to prevent webhook URL exposure in error output
           curl -sf -X POST "$SLACK_WEBHOOK" \
             -H "Content-Type: application/json" \
@@ -183,7 +270,7 @@ jobs:
                   \"type\": \"header\",
                   \"text\": {
                     \"type\": \"plain_text\",
-                    \"text\": \"Proxy Deployment Failed\",
+                    \"text\": \"Proxy Deployment Failed${ROLLBACK_MSG}\",
                     \"emoji\": true
                   }
                 },

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -94,8 +94,8 @@ jobs:
           cd proxy
           # Get the current active version ID before deploying
           VERSION_ID=$(npx wrangler versions list 2>/dev/null | grep -E '^\S+' | head -1 | awk '{print $1}' || echo "")
-          # Validate version ID format (UUID-like: alphanumeric with hyphens)
-          if [ -n "$VERSION_ID" ] && [[ "$VERSION_ID" =~ ^[a-f0-9-]+$ ]]; then
+          # Validate version ID format (UUID: 36 chars with hyphens, or 32-char hex)
+          if [ -n "$VERSION_ID" ] && [[ "$VERSION_ID" =~ ^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ || "$VERSION_ID" =~ ^[a-f0-9]{32}$ ]]; then
             echo "Current version ID: $VERSION_ID"
             echo "version_id=$VERSION_ID" >> $GITHUB_OUTPUT
             echo "has_previous_version=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -53,7 +53,8 @@ jobs:
         id: deployed
         run: |
           # Extract version, handling semver with pre-release tags (e.g., 1.0.0-beta.1)
-          DEPLOYED=$(curl -sf "$PROXY_URL/health" | jq -r '.version' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?' || echo "unknown")
+          # Pattern requires proper pre-release format: -identifier(.identifier)*
+          DEPLOYED=$(curl -sf "$PROXY_URL/health" | jq -r '.version' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?' || echo "unknown")
           echo "deployed_version=$DEPLOYED" >> $GITHUB_OUTPUT
           echo "Deployed version: $DEPLOYED"
 
@@ -111,12 +112,15 @@ jobs:
 
       - name: Deploy to Cloudflare Workers
         if: steps.check.outputs.should_deploy == 'true'
+        id: deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           cd proxy
           npx wrangler deploy
+          # Mark that deployment itself succeeded (for rollback if secrets/KV fail)
+          echo "deployed=true" >> $GITHUB_OUTPUT
 
       - name: Set Cloudflare secrets
         if: steps.check.outputs.should_deploy == 'true'
@@ -171,8 +175,24 @@ jobs:
       - name: Wait for deployment propagation
         if: steps.check.outputs.should_deploy == 'true'
         run: |
-          echo "Waiting 15 seconds for deployment to propagate..."
-          sleep 15
+          # Poll health endpoint until version matches or timeout (exponential backoff)
+          EXPECTED_VERSION="${{ steps.version.outputs.version }}"
+          MAX_ATTEMPTS=6
+          WAIT_TIME=5
+
+          echo "Waiting for deployment to propagate (expecting version: $EXPECTED_VERSION)..."
+          for i in $(seq 1 $MAX_ATTEMPTS); do
+            DEPLOYED=$(curl -sf "$PROXY_URL/health" | jq -r '.version' 2>/dev/null || echo "")
+            if [ "$DEPLOYED" = "$EXPECTED_VERSION" ]; then
+              echo "::notice::Deployment propagated successfully after $i attempt(s)"
+              exit 0
+            fi
+            echo "Attempt $i/$MAX_ATTEMPTS: version=$DEPLOYED (waiting ${WAIT_TIME}s...)"
+            sleep $WAIT_TIME
+            WAIT_TIME=$((WAIT_TIME + 5))  # Increase wait time each attempt
+          done
+
+          echo "::warning::Version propagation not confirmed after $MAX_ATTEMPTS attempts, proceeding with verification"
 
       - name: Verify deployment
         if: steps.check.outputs.should_deploy == 'true' && inputs.skip_verification != 'true'
@@ -189,21 +209,28 @@ jobs:
         id: rollback_check
         run: |
           # Determine if rollback should be attempted (simplifies subsequent conditions)
+          # Rollback if: verification failed, OR any post-deploy step failed while deploy succeeded
+          DEPLOY_SUCCEEDED="${{ steps.deploy.outputs.deployed == 'true' }}"
           VERIFICATION_FAILED="${{ steps.verify.outcome == 'failure' }}"
+          SECRETS_FAILED="${{ steps.deploy.outcome == 'success' && steps.store_version.outcome == 'failure' }}"
           DEPLOYMENT_COMPLETE="${{ steps.store_version.outputs.deployment_complete == 'true' }}"
           HAS_PREVIOUS="${{ steps.current_deployment.outputs.has_previous_version == 'true' }}"
 
-          if [ "$VERIFICATION_FAILED" = "true" ] && [ "$DEPLOYMENT_COMPLETE" = "true" ]; then
-            echo "should_rollback=true" >> $GITHUB_OUTPUT
-            if [ "$HAS_PREVIOUS" = "true" ]; then
-              echo "can_rollback=true" >> $GITHUB_OUTPUT
-            else
-              echo "can_rollback=false" >> $GITHUB_OUTPUT
+          # Rollback needed if verification failed OR if deploy succeeded but secrets/KV failed
+          if [ "$DEPLOY_SUCCEEDED" = "true" ]; then
+            if [ "$VERIFICATION_FAILED" = "true" ] || [ "$SECRETS_FAILED" = "true" ] || [ "$DEPLOYMENT_COMPLETE" != "true" ]; then
+              echo "should_rollback=true" >> $GITHUB_OUTPUT
+              if [ "$HAS_PREVIOUS" = "true" ]; then
+                echo "can_rollback=true" >> $GITHUB_OUTPUT
+              else
+                echo "can_rollback=false" >> $GITHUB_OUTPUT
+              fi
+              exit 0
             fi
-          else
-            echo "should_rollback=false" >> $GITHUB_OUTPUT
-            echo "can_rollback=false" >> $GITHUB_OUTPUT
           fi
+
+          echo "should_rollback=false" >> $GITHUB_OUTPUT
+          echo "can_rollback=false" >> $GITHUB_OUTPUT
 
       - name: Rollback on verification failure
         if: failure() && steps.rollback_check.outputs.should_rollback == 'true' && steps.rollback_check.outputs.can_rollback == 'true'
@@ -219,8 +246,8 @@ jobs:
           echo "rollback_performed=true" >> $GITHUB_OUTPUT
 
           # Verify rollback was successful
-          echo "Waiting 10 seconds for rollback to propagate..."
-          sleep 10
+          echo "Waiting 15 seconds for rollback to propagate..."
+          sleep 15
           echo "Verifying rollback health..."
           if curl -sf "$PROXY_URL/health" | jq -e '.status == "ok"' > /dev/null; then
             echo "::notice::Rollback verified - health check passed"

--- a/.github/workflows/test-admin-pr.yml
+++ b/.github/workflows/test-admin-pr.yml
@@ -105,8 +105,8 @@ jobs:
           echo "=== Proxy Process ==="
           ps aux | grep wrangler || true
           echo ""
-          echo "=== Test OAuth Token Endpoint (expect error - no valid code) ==="
-          curl -v -X POST http://localhost:8787/oauth/token \
+          echo "=== Test getAccessToken Endpoint (expect error - no valid code) ==="
+          curl -v -X POST http://localhost:8787/proxy/getAccessToken \
             -H "Content-Type: application/json" \
             -H "Origin: http://127.0.0.1:3333" \
             -d '{"code":"test_invalid_code","redirect_uri":"http://127.0.0.1:3333"}' 2>&1 || true

--- a/.github/workflows/test-demo1-pr.yml
+++ b/.github/workflows/test-demo1-pr.yml
@@ -102,8 +102,8 @@ jobs:
           echo "=== Proxy Process ==="
           ps aux | grep wrangler || true
           echo ""
-          echo "=== Test OAuth Token Endpoint (expect error - no valid code) ==="
-          curl -v -X POST http://localhost:8787/oauth/token \
+          echo "=== Test getAccessToken Endpoint (expect error - no valid code) ==="
+          curl -v -X POST http://localhost:8787/proxy/getAccessToken \
             -H "Content-Type: application/json" \
             -H "Origin: http://127.0.0.1:3333" \
             -d '{"code":"test_invalid_code","redirect_uri":"http://127.0.0.1:3333"}' 2>&1 || true

--- a/README.md
+++ b/README.md
@@ -553,27 +553,31 @@ Automatically deploys the proxy to Cloudflare Workers with version checking and 
 4. Deploy worker to Cloudflare
 5. Set Cloudflare secrets (CLIENT_ID, CLIENT_SECRET, etc.)
 6. Store deploy version in KV
-7. Wait 10 seconds for propagation
+7. Wait 15 seconds for propagation
 8. Run verification tests against deployed proxy
 9. **On test failure: Automatically rollback to previous version**
-10. Send Slack notification (success or failure with rollback status)
+10. Verify rollback with health check
+11. Send Slack notification (success or failure with rollback status)
 
 *Manual Trigger Inputs:*
 | Input | Description |
 |-------|-------------|
 | `skip_verification` | Skip post-deployment tests (use with caution) |
-| `force_deploy` | Deploy even if versions match |
+| `force_deploy` | Deploy even if versions match (use with caution - bypasses safety check) |
 
 *Automatic Rollback:*
 - If verification tests fail after deployment, the workflow automatically rolls back to the previous version
 - Rollback uses `wrangler versions deploy` to restore the prior deployment
-- Slack notification indicates "(rolled back)" when rollback occurs
+- After rollback, a health check verifies the rolled-back version is working
+- Slack notification indicates "(rolled back to [version])" when rollback occurs
+- If no previous version exists (first deployment), rollback is skipped with appropriate messaging
 - The workflow still reports as failed to alert of the issue
 
 *Version Checking:*
 - Compares the version in `proxy/package.json` with the version reported by `/health` endpoint
+- Supports semver with pre-release tags (e.g., `1.0.0-beta.1`)
 - If versions match, deployment is skipped (logs "Deployment Skipped" in summary)
-- Use `force_deploy: true` to override and deploy anyway
+- Use `force_deploy: true` to override (use with caution - for redeploying same version)
 
 **Deployment Pipeline:**
 1. PR merged to `production` triggers `deploy-admin.yml` and `deploy-proxy.yml`

--- a/README.md
+++ b/README.md
@@ -572,6 +572,7 @@ Automatically deploys the proxy to Cloudflare Workers with version checking and 
 - Slack notification indicates "(rolled back to [version])" when rollback occurs
 - If no previous version exists (first deployment), rollback is skipped with appropriate messaging
 - The workflow still reports as failed to alert of the issue
+- **Important:** Rollback restores the code version only, not Cloudflare secrets. Ensure secrets are compatible across versions. If you need to update secrets, update GitHub Secrets first, then deploy. Do not change secrets and code in the same deployment if they are incompatible.
 
 *Version Checking:*
 - Compares the version in `proxy/package.json` with the version reported by `/health` endpoint

--- a/README.md
+++ b/README.md
@@ -501,6 +501,7 @@ The `production` branch is protected with the following rules:
 | `pr-review-gemini.yml` | PR to production | AI security review using Google Gemini |
 | `test-admin-pr.yml` | PR to production | Runs Playwright tests against local wrangler proxy |
 | `codeql.yml` | PR to production | Security vulnerability scanning |
+| `deploy-proxy.yml` | Push to production (proxy/**) or manual | Deploys proxy to Cloudflare Workers with rollback |
 | `deploy-admin.yml` | Push to production | Deploys admin app to GitHub Pages |
 | `test-admin-deployed.yml` | After deploy | Tests the deployed admin app |
 | `release.yml` | After deployed tests pass | Creates GitHub release with version tag |
@@ -534,12 +535,50 @@ The `production` branch is protected with the following rules:
 - Prevents develop from becoming out-of-sync with production
 - **Note:** After a PR is merged, run `git pull` locally before making new commits
 
+**Proxy Deployment (`deploy-proxy.yml`):**
+
+Automatically deploys the proxy to Cloudflare Workers with version checking and automatic rollback on failure.
+
+*Triggers:*
+- **Automatic:** Push to `production` branch when `proxy/**` files change
+- **Manual:** Workflow dispatch with optional inputs
+
+*Workflow Steps:*
+1. Compare `proxy/package.json` version with deployed `/health` version
+2. Skip deployment if versions match (prevents redundant deploys)
+3. Capture current deployment version ID (for potential rollback)
+4. Deploy worker to Cloudflare
+5. Set Cloudflare secrets (CLIENT_ID, CLIENT_SECRET, etc.)
+6. Store deploy version in KV
+7. Wait 10 seconds for propagation
+8. Run verification tests against deployed proxy
+9. **On test failure: Automatically rollback to previous version**
+10. Send Slack notification (success or failure with rollback status)
+
+*Manual Trigger Inputs:*
+| Input | Description |
+|-------|-------------|
+| `skip_verification` | Skip post-deployment tests (use with caution) |
+| `force_deploy` | Deploy even if versions match |
+
+*Automatic Rollback:*
+- If verification tests fail after deployment, the workflow automatically rolls back to the previous version
+- Rollback uses `wrangler versions deploy` to restore the prior deployment
+- Slack notification indicates "(rolled back)" when rollback occurs
+- The workflow still reports as failed to alert of the issue
+
+*Version Checking:*
+- Compares the version in `proxy/package.json` with the version reported by `/health` endpoint
+- If versions match, deployment is skipped (logs "Deployment Skipped" in summary)
+- Use `force_deploy: true` to override and deploy anyway
+
 **Deployment Pipeline:**
-1. PR merged to `production` triggers `deploy-admin.yml`
-2. Admin app deployed to GitHub Pages
-3. `test-admin-deployed.yml` runs tests against deployed app
-4. On success, `release.yml` creates a new GitHub release
-5. Slack notifications sent for deployments and releases
+1. PR merged to `production` triggers `deploy-admin.yml` and `deploy-proxy.yml`
+2. Proxy deployed to Cloudflare Workers (with rollback safety)
+3. Admin app deployed to GitHub Pages
+4. `test-admin-deployed.yml` runs tests against deployed app
+5. On success, `release.yml` creates a new GitHub release
+6. Slack notifications sent for deployments and releases
 
 ### Required GitHub Secrets
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ A Vue 3 demonstration application showing OAuth integration with EEN.
 - Token refresh and revocation
 - Auto-refresh before token expiration
 
-**Deployment:** none, build your own locally. Note that you can not run demo1 and admin on the same local machine as they share a common port 3333
+**Deployment:** Local development only (not deployed to production). The demo1 app is tested via `test-demo1-pr.yml` on PRs but has no deployment workflow. Note that demo1 and admin share port 3333 and cannot run simultaneously on the same machine.
 
 ## Getting Started
 
@@ -497,9 +497,12 @@ The `production` branch is protected with the following rules:
 
 | Workflow | Trigger | Description |
 |----------|---------|-------------|
-| `pr-review.yml` | PR to production | AI code review using Claude Code Action |
-| `pr-review-gemini.yml` | PR to production | AI security review using Google Gemini |
-| `test-admin-pr.yml` | PR to production | Runs Playwright tests against local wrangler proxy |
+| `pr-review.yml` | PR to production/develop | AI code review using Claude Code Action |
+| `pr-review-gemini.yml` | PR to production/develop | AI security review using Google Gemini |
+| `test-admin-pr.yml` | PR to production | Runs admin Playwright tests against local proxy |
+| `test-demo1-pr.yml` | PR to production | Runs demo1 Playwright tests against local proxy |
+| `validate-branch-protection.yml` | PR to production/develop | Validates branch naming conventions |
+| `check-proxy-version.yml` | PR to production (proxy/**) | Checks if proxy version differs from deployed |
 | `codeql.yml` | PR to production | Security vulnerability scanning |
 | `deploy-proxy.yml` | Push to production (proxy/**) or manual | Deploys proxy to Cloudflare Workers with rollback |
 | `deploy-admin.yml` | Push to production | Deploys admin app to GitHub Pages |
@@ -638,8 +641,9 @@ Configure these variables in your repository settings (Settings > Secrets and va
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `VITE_PROXY_URL` | URL of the deployed Cloudflare proxy | `https://your-proxy.workers.dev` |
+| `VITE_REDIRECT_URI` | OAuth redirect URI (admin app URL) | `https://your-username.github.io/een-oauth-proxy` |
 
-**Important:** `VITE_PROXY_URL` must be set as a **Variable** (not a Secret) because:
+**Important:** These must be set as **Variables** (not Secrets) because:
 - The `test-admin-deployed.yml` workflow uses `${{ vars.VITE_PROXY_URL }}` to test against the production proxy
 - Without this variable, tests fall back to `localhost:8787` which doesn't exist in GitHub Actions
 - The workflow will fail early with a clear error if this variable is not configured
@@ -713,6 +717,12 @@ This project includes a Claude Code skill for automating the PR creation and rev
 | `ALLOWED_API_DOMAINS` | Comma-separated allowed API domains for SSRF protection | `eagleeyenetworks.com` |
 | `ENVIRONMENT` | `development` or `production` | `development` |
 | `REFRESH_TOKEN_TTL` | Session TTL buffer in seconds (see below) | `86400` |
+| `RATE_LIMIT_ENABLED` | Enable/disable rate limiting | `true` (default) |
+| `RATE_LIMIT_WINDOW` | Rate limit window in seconds | `60` (default) |
+| `RATE_LIMIT_HEALTH` | Max requests per window for `/health` | `60` (default) |
+| `RATE_LIMIT_OAUTH` | Max requests per window for `/proxy/*` | `30` (default) |
+| `RATE_LIMIT_ADMIN` | Max requests per window for `/admin/*` | `60` (default) |
+| `RATE_LIMIT_UNKNOWN` | Max requests per window for unidentified clients | `5` (default) |
 
 **Session TTL and Refresh Token Expiration:**
 
@@ -767,6 +777,7 @@ These endpoints require:
 |--------|----------|-------------|
 | GET | `/admin/version` | Get proxy version and deploy time |
 | GET | `/admin/sessionsCount` | Count active sessions stored in KV |
+| GET | `/admin/rateLimitStats` | Get rate limiting statistics by client IP |
 | DELETE | `/admin/removeSessions` | Remove all sessions except current user's session |
 | POST | `/admin/revokeAll` | Emergency: revoke all tokens at EEN and delete all sessions |
 

--- a/demo1/package-lock.json
+++ b/demo1/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-demo1",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-demo1",
-      "version": "0.0.49",
+      "version": "0.0.50",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/demo1/package.json
+++ b/demo1/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-demo1",
   "displayName": "EEN OAuth Demo1",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "private": true,
   "type": "module",
   "scripts": {

--- a/demo1/tests/auth-flows.spec.js
+++ b/demo1/tests/auth-flows.spec.js
@@ -139,7 +139,6 @@ test.describe('Authentication Flows', () => {
         signal: controller.signal
       })
 
-      clearTimeout(timeoutId)
       console.log(`📋 Refresh response status: ${refreshResponse.status}`)
 
       // Step 6: Verify refresh fails (401 - session no longer exists)
@@ -149,11 +148,12 @@ test.describe('Authentication Flows', () => {
       const responseData = await refreshResponse.json().catch(() => ({}))
       console.log(`📋 Response: ${JSON.stringify(responseData)}`)
     } catch (error) {
-      clearTimeout(timeoutId)
       if (error.name === 'AbortError') {
         throw new Error(`Refresh request timed out after ${MAX_TEST_TIMEOUT / 1000} seconds`)
       }
       throw error
+    } finally {
+      clearTimeout(timeoutId)
     }
 
     console.log('\n✅ Token refresh after revocation test completed!\n')

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.35",
+  "version": "1.2.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.2.35",
+      "version": "1.2.36",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.33",
+  "version": "1.2.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.2.33",
+      "version": "1.2.34",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.34",
+  "version": "1.2.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.2.34",
+      "version": "1.2.35",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.36",
+  "version": "1.2.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.2.36",
+      "version": "1.2.37",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.33",
+  "version": "1.2.34",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.36",
+  "version": "1.2.37",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.35",
+  "version": "1.2.36",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.34",
+  "version": "1.2.35",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/scripts/deploy.js
+++ b/proxy/scripts/deploy.js
@@ -100,14 +100,24 @@ run('npx wrangler deploy')
 console.log('')
 console.log('Setting secrets...')
 
+// Allowlist of valid secret names (prevents command injection via modified array)
+const VALID_SECRET_NAMES = new Set([
+  'CLIENT_ID',
+  'CLIENT_SECRET',
+  'ADMIN_EMAILS',
+  'ALLOWED_ORIGINS',
+  'ALLOWED_API_DOMAINS',
+  'REFRESH_TOKEN_TTL'
+])
+
 const secrets = ['CLIENT_ID', 'CLIENT_SECRET', 'ADMIN_EMAILS', 'ALLOWED_ORIGINS', 'ALLOWED_API_DOMAINS', 'REFRESH_TOKEN_TTL']
 
 for (const secret of secrets) {
   const value = process.env[secret]
   if (value) {
-    // Validate secret name contains only safe characters (defense in depth)
-    if (!/^[A-Z_]+$/.test(secret)) {
-      console.warn(`Warning: Invalid secret name format: ${secret}`)
+    // Validate secret name against allowlist (defense in depth)
+    if (!VALID_SECRET_NAMES.has(secret)) {
+      console.warn(`Warning: Secret name '${secret}' not in allowlist, skipping`)
       continue
     }
     console.log(`Setting ${secret}...`)
@@ -135,16 +145,23 @@ console.log('Storing deploy version in KV...')
 const namespaceMatch = wranglerToml.match(/id = "([^"]+)"/)
 if (namespaceMatch) {
   const namespaceId = namespaceMatch[1]
-  try {
-    execSync(
-      `npx wrangler kv key put DEPLOY_VERSION "${versionString}" --namespace-id="${namespaceId}" --remote`,
-      {
-        cwd: projectRoot,
-        stdio: 'inherit'
-      }
-    )
-  } catch (error) {
-    console.warn('Warning: Failed to store deploy version')
+  // Validate namespace ID format (32-char hex) to prevent injection
+  if (!/^[a-f0-9]{32}$/.test(namespaceId)) {
+    console.warn('Warning: Invalid namespace ID format, skipping version storage')
+  } else {
+    try {
+      // Use stdin for version string to prevent shell injection
+      execSync(
+        `npx wrangler kv key put DEPLOY_VERSION --namespace-id="${namespaceId}" --remote`,
+        {
+          cwd: projectRoot,
+          stdio: ['pipe', 'inherit', 'inherit'],
+          input: versionString
+        }
+      )
+    } catch (error) {
+      console.warn('Warning: Failed to store deploy version')
+    }
   }
 }
 

--- a/proxy/scripts/deploy.js
+++ b/proxy/scripts/deploy.js
@@ -105,6 +105,11 @@ const secrets = ['CLIENT_ID', 'CLIENT_SECRET', 'ADMIN_EMAILS', 'ALLOWED_ORIGINS'
 for (const secret of secrets) {
   const value = process.env[secret]
   if (value) {
+    // Validate secret name contains only safe characters (defense in depth)
+    if (!/^[A-Z_]+$/.test(secret)) {
+      console.warn(`Warning: Invalid secret name format: ${secret}`)
+      continue
+    }
     console.log(`Setting ${secret}...`)
     try {
       // Pass secret value via stdin to prevent shell injection

--- a/proxy/scripts/deploy.js
+++ b/proxy/scripts/deploy.js
@@ -107,9 +107,12 @@ for (const secret of secrets) {
   if (value) {
     console.log(`Setting ${secret}...`)
     try {
-      execSync(`echo "${value}" | npx wrangler secret put ${secret}`, {
+      // Pass secret value via stdin to prevent shell injection
+      // Using input option instead of shell interpolation for security
+      execSync(`npx wrangler secret put ${secret}`, {
         cwd: projectRoot,
-        stdio: 'pipe'
+        stdio: ['pipe', 'pipe', 'pipe'],
+        input: value
       })
     } catch (error) {
       console.warn(`Warning: Failed to set ${secret}`)

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -131,6 +131,7 @@ function isValidEenUrl(url, env) {
     // Block IP addresses (IPv4, IPv6, and numeric representations)
     // IPv4: 192.168.1.1
     // IPv6: [::1], [fe80::1], or with :: shorthand
+    // IPv4-mapped IPv6: ::ffff:192.0.2.1, 0:0:0:0:0:ffff:192.0.2.1
     // Numeric: 2130706433 (decimal representation of 127.0.0.1)
     // Octal/Hex: 0177.0.0.1, 0x7f.0.0.1
     const isIPv4 = /^\d+\.\d+\.\d+\.\d+$/.test(hostname)
@@ -139,10 +140,12 @@ function isValidEenUrl(url, env) {
     const isIPv6Bracketed = /^\[.+\]$/.test(hostname)
     const isIPv6Shorthand = hostname.includes('::')
     const isIPv6Full = /^[0-9a-f]+:[0-9a-f]+:/i.test(hostname)
+    // IPv4-mapped/compatible IPv6 addresses (e.g., ::ffff:192.168.1.1 or containing IPv4 after colon)
+    const isIPv4Mapped = /:[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/.test(hostname)
     const isNumericIP = /^\d+$/.test(hostname)
     const isOctalOrHex = /^0[0-7x]/i.test(hostname) || /\.0[0-7x]/i.test(hostname)
 
-    if (isIPv4 || isIPv6Bracketed || isIPv6Shorthand || isIPv6Full || isNumericIP || isOctalOrHex) {
+    if (isIPv4 || isIPv6Bracketed || isIPv6Shorthand || isIPv6Full || isIPv4Mapped || isNumericIP || isOctalOrHex) {
       debugLog(env, `[SSRF] Blocked IP-based hostname: ${truncateForLog(hostname)}`)
       return false
     }

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -166,14 +166,12 @@ function isValidEenUrl(url, env) {
       allowedDomains = cachedAllowlist
     } else {
       // Parse and cache the allowlist
-      // Limit config string length to prevent DoS via large config
-      const wasTruncated = rawAllowedDomains.length > MAX_ALLOWED_DOMAINS_CONFIG_LENGTH
-      if (wasTruncated) {
-        debugLog(env, `[WARNING] ALLOWED_API_DOMAINS truncated from ${rawAllowedDomains.length} to ${MAX_ALLOWED_DOMAINS_CONFIG_LENGTH} chars`)
+      // Reject if config exceeds limit (fail-safe to prevent misconfiguration)
+      if (rawAllowedDomains.length > MAX_ALLOWED_DOMAINS_CONFIG_LENGTH) {
+        debugLog(env, `[SSRF] ALLOWED_API_DOMAINS config too long (${rawAllowedDomains.length} > ${MAX_ALLOWED_DOMAINS_CONFIG_LENGTH}), rejecting request`)
+        return false
       }
-      const allowedDomainsStr = wasTruncated
-        ? rawAllowedDomains.substring(0, MAX_ALLOWED_DOMAINS_CONFIG_LENGTH)
-        : rawAllowedDomains
+      const allowedDomainsStr = rawAllowedDomains
       allowedDomains = allowedDomainsStr
         .split(',')
         .map((d) => d.trim().toLowerCase())

--- a/scripts/test-production-proxy.sh
+++ b/scripts/test-production-proxy.sh
@@ -32,12 +32,13 @@ NC='\033[0m' # No Color
 # Brief mode - compact output for CI/deployment
 BRIEF="${BRIEF:-0}"
 
-# Default production proxy URL
+# Default production proxy URL (can be overridden via first argument or PROXY_URL env var)
 DEFAULT_PROXY_URL="https://een-oauth-proxy.klaushofrichter.workers.dev"
-PROXY_URL="${1:-$DEFAULT_PROXY_URL}"
+PROXY_URL="${1:-${PROXY_URL:-$DEFAULT_PROXY_URL}}"
 
 # Allowed origin for CORS tests (must match proxy's ALLOWED_ORIGINS)
-ALLOWED_ORIGIN="https://klaushofrichter.github.io"
+# Can be overridden via ALLOWED_ORIGIN environment variable for forks/other deployments
+ALLOWED_ORIGIN="${ALLOWED_ORIGIN:-https://klaushofrichter.github.io}"
 
 # Track results
 PASSED=0

--- a/scripts/test-production-proxy.sh
+++ b/scripts/test-production-proxy.sh
@@ -138,7 +138,7 @@ run_test "No session returns 401" "401" "$NOSESSION"
 [ "$BRIEF" != "1" ] && echo -e "\n${BLUE}7. Authentication - Invalid Session${NC}"
 INVALID_SESSION=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 -X POST "$PROXY_URL/proxy/refreshAccessToken" \
   -H "Origin: $ALLOWED_ORIGIN" \
-  -H "Cookie: session_id=invalid-session-12345" 2>/dev/null || echo "000")
+  -H "Cookie: sessionId=invalid-session-12345" 2>/dev/null || echo "000")
 run_test "Invalid session rejected" "401" "$INVALID_SESSION"
 
 # 8. Admin Endpoint Without Auth

--- a/scripts/upload-github-secrets.sh
+++ b/scripts/upload-github-secrets.sh
@@ -58,6 +58,8 @@ upload_secret() {
     fi
 
     # Extract value after first '=' and strip surrounding quotes
+    # Note: This simple quote stripping doesn't handle escaped quotes within values.
+    # If your secrets contain literal \" sequences, edit them manually via GitHub UI.
     local value="${line#*=}"
     value="${value#\"}"
     value="${value%\"}"


### PR DESCRIPTION
## Summary
- Add automatic rollback when proxy deployment verification fails
- Add automatic deployment trigger when proxy version changes
- Fix documentation discrepancies and incorrect endpoint references
- Document deploy-proxy workflow including rollback feature

## Changes

### Proxy Deployment Workflow (`deploy-proxy.yml`)
- **Automatic trigger:** Deploys on push to production when `proxy/**` files change
- **Version checking:** Compares package.json version with deployed /health version, skips if matching
- **Automatic rollback:** If verification tests fail, automatically rolls back to previous version
- **New inputs:** `force_deploy` to override version check, `skip_verification` to skip tests

### Documentation Fixes
- Fix incorrect `/oauth/token` endpoint references in test workflows (should be `/proxy/getAccessToken`)
- Add `VITE_REDIRECT_URI` to Required GitHub Variables
- Add `/admin/rateLimitStats` to Admin Endpoints documentation
- Add rate limiting environment variables (`RATE_LIMIT_*`)
- Add missing workflows to table: `test-demo1-pr.yml`, `validate-branch-protection.yml`, `check-proxy-version.yml`
- Clarify demo1 deployment status (local dev only)
- Document deploy-proxy workflow with rollback feature

## Test plan
- [ ] Merge PR to production
- [ ] Verify deploy-proxy workflow triggers automatically (if proxy version differs)
- [ ] Verify workflow skips deployment if versions match
- [ ] Test manual trigger with `force_deploy: true`
- [ ] Verify rollback works by intentionally breaking tests (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)