### PR TITLE
Fix version propagation check

### DIFF
--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -158,8 +158,8 @@ jobs:
           cd proxy
           DEPLOY_TIME=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
           VERSION_STRING="een-oauth-proxy - ${{ steps.version.outputs.version }} - $DEPLOY_TIME"
-          # Get namespace ID from wrangler.toml (look for id after kv_namespaces section)
-          NAMESPACE_ID=$(awk '/\[\[kv_namespaces\]\]/,/^$/' wrangler.toml | grep 'id = "' | head -1 | sed 's/.*id = "\([^"]*\)".*/\1/')
+          # Get namespace ID from wrangler.toml (look for id within 5 lines after kv_namespaces section)
+          NAMESPACE_ID=$(grep -A 5 '\[\[kv_namespaces\]\]' wrangler.toml | grep 'id = "' | head -1 | sed 's/.*id = "\([^"]*\)".*/\1/')
           # Validate namespace ID was found and has correct format (32-char hex)
           if [ -z "$NAMESPACE_ID" ]; then
             echo "::error::Could not find KV namespace ID in wrangler.toml"
@@ -187,7 +187,8 @@ jobs:
           echo "Waiting for deployment to propagate (expecting version: $EXPECTED_VERSION)..."
           for i in $(seq 1 $MAX_ATTEMPTS); do
             DEPLOYED=$(curl -sf "$PROXY_URL/health" | jq -r '.version' 2>/dev/null || echo "")
-            if echo "$DEPLOYED" | grep -q "$EXPECTED_VERSION"; then
+            # Use word boundaries to prevent false matches (e.g., "1.2.3" matching "1.2.38")
+            if echo "$DEPLOYED" | grep -qE "(^|[^0-9])${EXPECTED_VERSION}([^0-9]|$)"; then
               echo "::notice::Deployment propagated successfully after $i attempt(s) - version: $DEPLOYED"
               exit 0
             fi
@@ -371,44 +372,23 @@ jobs:
           elif [ "${{ steps.current_deployment.outputs.has_previous_version }}" != "true" ]; then
             ROLLBACK_STATUS=" (rollback not possible - no previous version)"
           fi
+          # Build JSON safely using jq to prevent injection via special characters
           # Use env var to prevent webhook URL exposure in error output
-          curl -sf -X POST "$SLACK_WEBHOOK" \
-            -H "Content-Type: application/json" \
-            -d "{
-              \"blocks\": [
-                {
-                  \"type\": \"header\",
-                  \"text\": {
-                    \"type\": \"plain_text\",
-                    \"text\": \"Proxy Deployment Failed${ROLLBACK_STATUS}\",
-                    \"emoji\": true
-                  }
-                },
-                {
-                  \"type\": \"section\",
-                  \"fields\": [
-                    {
-                      \"type\": \"mrkdwn\",
-                      \"text\": \"*Version:*\n${VERSION}\"
-                    },
-                    {
-                      \"type\": \"mrkdwn\",
-                      \"text\": \"*Status:*\n:x: Failed\"
-                    }
-                  ]
-                },
-                {
-                  \"type\": \"actions\",
-                  \"elements\": [
-                    {
-                      \"type\": \"button\",
-                      \"text\": {
-                        \"type\": \"plain_text\",
-                        \"text\": \"View Workflow\"
-                      },
-                      \"url\": \"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"
-                    }
-                  ]
-                }
+          jq -n \
+            --arg title "Proxy Deployment Failed${ROLLBACK_STATUS}" \
+            --arg version "$VERSION" \
+            --arg url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{
+              blocks: [
+                {type: "header", text: {type: "plain_text", text: $title, emoji: true}},
+                {type: "section", fields: [
+                  {type: "mrkdwn", text: ("*Version:*\n" + $version)},
+                  {type: "mrkdwn", text: "*Status:*\n:x: Failed"}
+                ]},
+                {type: "actions", elements: [
+                  {type: "button", text: {type: "plain_text", text: "View Workflow"}, url: $url}
+                ]}
               ]
-            }"
+            }' | curl -sf -X POST "$SLACK_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d @-

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -158,8 +158,8 @@ jobs:
           cd proxy
           DEPLOY_TIME=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
           VERSION_STRING="een-oauth-proxy - ${{ steps.version.outputs.version }} - $DEPLOY_TIME"
-          # Get namespace ID from wrangler.toml (look for id within 5 lines after kv_namespaces section)
-          NAMESPACE_ID=$(grep -A 5 '\[\[kv_namespaces\]\]' wrangler.toml | grep 'id = "' | head -1 | sed 's/.*id = "\([^"]*\)".*/\1/')
+          # Get namespace ID from wrangler.toml (look for id within 10 lines after kv_namespaces section)
+          NAMESPACE_ID=$(grep -A 10 '\[\[kv_namespaces\]\]' wrangler.toml | grep 'id = "' | head -1 | sed 's/.*id = "\([^"]*\)".*/\1/')
           # Validate namespace ID was found and has correct format (32-char hex)
           if [ -z "$NAMESPACE_ID" ]; then
             echo "::error::Could not find KV namespace ID in wrangler.toml"
@@ -187,8 +187,8 @@ jobs:
           echo "Waiting for deployment to propagate (expecting version: $EXPECTED_VERSION)..."
           for i in $(seq 1 $MAX_ATTEMPTS); do
             DEPLOYED=$(curl -sf "$PROXY_URL/health" | jq -r '.version' 2>/dev/null || echo "")
-            # Use word boundaries to prevent false matches (e.g., "1.2.3" matching "1.2.38")
-            if echo "$DEPLOYED" | grep -qE "(^|[^0-9])${EXPECTED_VERSION}([^0-9]|$)"; then
+            # Use literal matching with version surrounded by " - " delimiters (format: "name - version - timestamp")
+            if echo "$DEPLOYED" | grep -qF "- $EXPECTED_VERSION -"; then
               echo "::notice::Deployment propagated successfully after $i attempt(s) - version: $DEPLOYED"
               exit 0
             fi
@@ -364,6 +364,7 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: |
+          set -o pipefail
           VERSION="${{ steps.version.outputs.version }}"
           VERSION="${VERSION:-unknown}"
           ROLLBACK_STATUS=""

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -178,6 +178,8 @@ jobs:
         id: wait_propagation
         run: |
           # Poll health endpoint until version matches or timeout (exponential backoff)
+          # Note: Health endpoint returns full version string like "een-oauth-proxy - 1.2.37 - timestamp"
+          # so we check if the expected version number is contained in the response
           EXPECTED_VERSION="${{ steps.version.outputs.version }}"
           MAX_ATTEMPTS=6
           WAIT_TIME=5
@@ -185,8 +187,8 @@ jobs:
           echo "Waiting for deployment to propagate (expecting version: $EXPECTED_VERSION)..."
           for i in $(seq 1 $MAX_ATTEMPTS); do
             DEPLOYED=$(curl -sf "$PROXY_URL/health" | jq -r '.version' 2>/dev/null || echo "")
-            if [ "$DEPLOYED" = "$EXPECTED_VERSION" ]; then
-              echo "::notice::Deployment propagated successfully after $i attempt(s)"
+            if echo "$DEPLOYED" | grep -q "$EXPECTED_VERSION"; then
+              echo "::notice::Deployment propagated successfully after $i attempt(s) - version: $DEPLOYED"
               exit 0
             fi
             echo "Attempt $i/$MAX_ATTEMPTS: version=$DEPLOYED (waiting ${WAIT_TIME}s...)"

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.40",
+  "version": "1.2.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.2.40",
+      "version": "1.2.41",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.39",
+  "version": "1.2.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.2.39",
+      "version": "1.2.40",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.37",
+  "version": "1.2.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.2.37",
+      "version": "1.2.39",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.40",
+  "version": "1.2.41",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.37",
+  "version": "1.2.39",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.39",
+  "version": "1.2.40",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/scripts/deploy.js
+++ b/proxy/scripts/deploy.js
@@ -110,10 +110,15 @@ const VALID_SECRET_NAMES = new Set([
   'REFRESH_TOKEN_TTL'
 ])
 
+// Critical secrets that must be set for the proxy to function
+const CRITICAL_SECRETS = new Set(['CLIENT_ID', 'CLIENT_SECRET'])
+
 const secrets = ['CLIENT_ID', 'CLIENT_SECRET', 'ADMIN_EMAILS', 'ALLOWED_ORIGINS', 'ALLOWED_API_DOMAINS', 'REFRESH_TOKEN_TTL']
 
 for (const secret of secrets) {
   const value = process.env[secret]
+  const isCritical = CRITICAL_SECRETS.has(secret)
+
   if (value) {
     // Validate secret name against allowlist (defense in depth)
     if (!VALID_SECRET_NAMES.has(secret)) {
@@ -130,9 +135,17 @@ for (const secret of secrets) {
         input: value
       })
     } catch (error) {
+      if (isCritical) {
+        console.error(`Error: Failed to set critical secret ${secret}`)
+        process.exit(1)
+      }
       console.warn(`Warning: Failed to set ${secret}`)
     }
   } else {
+    if (isCritical) {
+      console.error(`Error: Critical secret ${secret} not found in environment`)
+      process.exit(1)
+    }
     console.warn(`Warning: ${secret} not found in environment`)
   }
 }

--- a/proxy/scripts/deploy.js
+++ b/proxy/scripts/deploy.js
@@ -91,15 +91,6 @@ if (!wranglerToml.includes('id = "') || wranglerToml.includes('# id = "')) {
   }
 }
 
-// Deploy worker
-console.log('')
-console.log('Deploying worker...')
-run('npx wrangler deploy')
-
-// Set secrets
-console.log('')
-console.log('Setting secrets...')
-
 // Allowlist of valid secret names (prevents command injection via modified array)
 const VALID_SECRET_NAMES = new Set([
   'CLIENT_ID',
@@ -111,13 +102,33 @@ const VALID_SECRET_NAMES = new Set([
 ])
 
 // Critical secrets that must be set for the proxy to function
-const CRITICAL_SECRETS = new Set(['CLIENT_ID', 'CLIENT_SECRET'])
+const CRITICAL_SECRETS = ['CLIENT_ID', 'CLIENT_SECRET']
 
 const secrets = ['CLIENT_ID', 'CLIENT_SECRET', 'ADMIN_EMAILS', 'ALLOWED_ORIGINS', 'ALLOWED_API_DOMAINS', 'REFRESH_TOKEN_TTL']
 
+// Pre-validate all critical secrets exist before any deployment actions
+console.log('')
+console.log('Validating critical secrets...')
+const missingCritical = CRITICAL_SECRETS.filter(secret => !process.env[secret])
+if (missingCritical.length > 0) {
+  console.error(`Error: Missing critical secrets: ${missingCritical.join(', ')}`)
+  console.error('Aborting deployment - all critical secrets must be present')
+  process.exit(1)
+}
+console.log('All critical secrets present')
+
+// Deploy worker
+console.log('')
+console.log('Deploying worker...')
+run('npx wrangler deploy')
+
+// Set secrets
+console.log('')
+console.log('Setting secrets...')
+
 for (const secret of secrets) {
   const value = process.env[secret]
-  const isCritical = CRITICAL_SECRETS.has(secret)
+  const isCritical = CRITICAL_SECRETS.includes(secret)
 
   if (value) {
     // Validate secret name against allowlist (defense in depth)
@@ -142,10 +153,7 @@ for (const secret of secrets) {
       console.warn(`Warning: Failed to set ${secret}`)
     }
   } else {
-    if (isCritical) {
-      console.error(`Error: Critical secret ${secret} not found in environment`)
-      process.exit(1)
-    }
+    // Non-critical secrets can be missing (critical ones were pre-validated)
     console.warn(`Warning: ${secret} not found in environment`)
   }
 }


### PR DESCRIPTION
Fix version propagation check to use contains instead of exact match.

The health endpoint returns full version string like `een-oauth-proxy - 1.2.37 - timestamp`, not just the semver. Changed from exact equality to grep contains check.

This fixes the false warning "Version propagation not confirmed" that was appearing even when the correct version was deployed.