### PR TITLE
Add local version script and update wrangler

### DIFF
--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.48",
+  "version": "1.2.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.2.48",
+      "version": "1.2.49",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",
@@ -3098,9 +3098,9 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "4.57.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.57.0.tgz",
-      "integrity": "sha512-JTVHmL2zr5PUJ22kT21fNXZBgVm4WzXSHsVc+VVIRANBVgTwn6EikXBx1DMyvHDQP6vkaojuyrRjeasB7rxV9A==",
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.58.0.tgz",
+      "integrity": "sha512-Jm6EYtlt8iUcznOCPSMYC54DYkwrMNESzbH0Vh3GFHv/7XVw5gBC13YJAB+nWMRGJ+6B2dMzy/NVQS4ONL51Pw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -3108,10 +3108,10 @@
         "@cloudflare/unenv-preset": "2.8.0",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.27.0",
-        "miniflare": "4.20260103.0",
+        "miniflare": "4.20260107.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260103.0"
+        "workerd": "1.20260107.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -3124,7 +3124,7 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260103.0"
+        "@cloudflare/workers-types": "^4.20260107.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -3149,9 +3149,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260103.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260103.0.tgz",
-      "integrity": "sha512-jhpwADN14T+plfDt3ljYAJL2+nTdTJQ3I/OpedweOz1l2jYZITRD+EI0zUpOzGJRqCE1k5SCkHUXINsWaE6aKg==",
+      "version": "1.20260107.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260107.1.tgz",
+      "integrity": "sha512-Srwe/IukVppkMU2qTndkFaKCmZBI7CnZoq4Y0U0gD/8158VGzMREHTqCii4IcCeHifwrtDqTWu8EcA1VBKI4mg==",
       "cpu": [
         "x64"
       ],
@@ -3166,9 +3166,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260103.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260103.0.tgz",
-      "integrity": "sha512-RoVMzq+TMoKTPr0aewwRasJumMqNYlBJuTC7ZwPAjfjuqedkLfvLx8GsXkW5zpyUMEsUciRh4DPJfDPKVgAy9g==",
+      "version": "1.20260107.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260107.1.tgz",
+      "integrity": "sha512-aAYwU7zXW+UZFh/a4vHP5cs1ulTOcDRLzwU9547yKad06RlZ6ioRm7ovjdYvdqdmbI8mPd99v4LN9gMmecazQw==",
       "cpu": [
         "arm64"
       ],
@@ -3183,9 +3183,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260103.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260103.0.tgz",
-      "integrity": "sha512-JQN4FnsTiBgtLF/9ABcgJjew+QxonE3ZxnqCT355x45mksJuArjD2iZ4kLZQ16OSEAkno8fmVw0VvljdGd41kg==",
+      "version": "1.20260107.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260107.1.tgz",
+      "integrity": "sha512-Wh7xWtFOkk6WY3CXe3lSqZ1anMkFcwy+qOGIjtmvQ/3nCOaG34vKNwPIE9iwryPupqkSuDmEqkosI1UUnSTh1A==",
       "cpu": [
         "x64"
       ],
@@ -3200,9 +3200,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260103.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260103.0.tgz",
-      "integrity": "sha512-kjMHGrnnZrOyQnXuJ8YpblKtjkv45o+utIYk4AZUoaUBbEltwn7CXucDa0MG0jsDDvCCwRabdaJSAXHV6JB/ZQ==",
+      "version": "1.20260107.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260107.1.tgz",
+      "integrity": "sha512-NI0/5rdssdZZKYHxNG4umTmMzODByq86vSCEk8u4HQbGhRCQo7rV1eXn84ntSBdyWBzWdYGISCbeZMsgfIjSTg==",
       "cpu": [
         "arm64"
       ],
@@ -3217,9 +3217,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260103.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260103.0.tgz",
-      "integrity": "sha512-M7mZHV6uWVE+Mf8r/nT6/21N1+Z4JmZTPJjek3rB4n7netOJGZIUQwyuY+5gwOnq+qJsqHoU/RP7b4lFSoMZuQ==",
+      "version": "1.20260107.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260107.1.tgz",
+      "integrity": "sha512-gmBMqs606Gd/IhBEBPSL/hJAqy2L8IyPUjKtoqd/Ccy7GQxbSc0rYlRkxbQ9YzmqnuhrTVYvXuLscyWrpmAJkw==",
       "cpu": [
         "x64"
       ],
@@ -3718,9 +3718,9 @@
       }
     },
     "node_modules/wrangler/node_modules/miniflare": {
-      "version": "4.20260103.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260103.0.tgz",
-      "integrity": "sha512-iuSU0e+KMuFD7gxuPKoJXFi6cvDu/w/lQP4Wayq3v+YsmZ0dVMAJY9LMZ0TKMLicdAj2So9WcReAhJmJJ9Ppnw==",
+      "version": "4.20260107.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260107.0.tgz",
+      "integrity": "sha512-X93sXczqbBq9ixoM6jnesmdTqp+4baVC/aM/DuPpRS0LK0XtcqaO75qPzNEvDEzBAHxwMAWRIum/9hg32YB8iA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3732,7 +3732,7 @@
         "sharp": "^0.33.5",
         "stoppable": "1.1.0",
         "undici": "7.14.0",
-        "workerd": "1.20260103.0",
+        "workerd": "1.20260107.1",
         "ws": "8.18.0",
         "youch": "4.1.0-beta.10",
         "zod": "^3.25.76"
@@ -3745,9 +3745,9 @@
       }
     },
     "node_modules/wrangler/node_modules/workerd": {
-      "version": "1.20260103.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260103.0.tgz",
-      "integrity": "sha512-uB5eliFHVCdPD3uaPGe6zNRFjWzijOb26c0/1oXKmQFUSUR7GFPCTTd0iJXZAGKZDZ0DNgzQCPoolWelz6W5Zg==",
+      "version": "1.20260107.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260107.1.tgz",
+      "integrity": "sha512-4ylAQJDdJZdMAUl2SbJgTa77YHpa88l6qmhiuCLNactP933+rifs7I0w1DslhUIFgydArUX5dNLAZnZhT7Bh7g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -3758,11 +3758,11 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260103.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20260103.0",
-        "@cloudflare/workerd-linux-64": "1.20260103.0",
-        "@cloudflare/workerd-linux-arm64": "1.20260103.0",
-        "@cloudflare/workerd-windows-64": "1.20260103.0"
+        "@cloudflare/workerd-darwin-64": "1.20260107.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260107.1",
+        "@cloudflare/workerd-linux-64": "1.20260107.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260107.1",
+        "@cloudflare/workerd-windows-64": "1.20260107.1"
       }
     },
     "node_modules/ws": {

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.49",
+  "version": "1.2.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.2.49",
+      "version": "1.2.50",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.49",
+  "version": "1.2.50",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,10 +1,10 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.2.48",
+  "version": "1.2.49",
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "npm run stop && wrangler dev",
+    "dev": "npm run stop && node scripts/set-local-version.js && wrangler dev",
     "stop": "lsof -ti :8787 | xargs kill -9 2>/dev/null || echo 'Port 8787 is free'",
     "deploy": "node scripts/deploy.js",
     "test": "vitest run",

--- a/proxy/scripts/set-local-version.js
+++ b/proxy/scripts/set-local-version.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Sets the DEPLOY_VERSION in local KV storage for development
+ * This ensures /health returns the correct version during local dev
+ */
+
+import { execSync } from 'child_process'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const projectRoot = join(__dirname, '..')
+
+// Read version from package.json
+const packageJson = JSON.parse(readFileSync(join(projectRoot, 'package.json'), 'utf-8'))
+const version = packageJson.version
+
+console.log(`Setting local DEPLOY_VERSION to v${version}`)
+
+try {
+  execSync(
+    `npx wrangler kv key put DEPLOY_VERSION "v${version}" --binding=EEN_OAUTH_SESSIONS --local`,
+    {
+      cwd: projectRoot,
+      stdio: 'inherit'
+    }
+  )
+} catch (error) {
+  // Non-fatal - dev server will still work, just with 'unknown' version
+  console.warn('Warning: Could not set local version (this is non-fatal)')
+}

--- a/proxy/scripts/set-local-version.js
+++ b/proxy/scripts/set-local-version.js
@@ -17,9 +17,16 @@ const projectRoot = join(__dirname, '..')
 const packageJson = JSON.parse(readFileSync(join(projectRoot, 'package.json'), 'utf-8'))
 const version = packageJson.version
 
+// Validate version format to prevent command injection (semver pattern)
+if (!version || !/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(version)) {
+  console.warn(`Warning: Invalid version format "${version}", skipping local version setup`)
+  process.exit(0)
+}
+
 console.log(`Setting local DEPLOY_VERSION to v${version}`)
 
 try {
+  // Version is validated above, safe to use in command
   execSync(
     `npx wrangler kv key put DEPLOY_VERSION "v${version}" --binding=EEN_OAUTH_SESSIONS --local`,
     {


### PR DESCRIPTION
## Summary

- Add `set-local-version.js` script to write `DEPLOY_VERSION` to local KV when starting dev server
- Update dev script to run version script before `wrangler dev`
- Update wrangler from 4.57.0 to 4.58.0

This ensures the `/health` endpoint returns the correct version during local development instead of showing an outdated cached value.

## Versions

| Component | Version |
|-----------|---------|
| Proxy | 1.2.49 |
| Admin | 1.0.42 |
| Demo1 | 0.0.50 |

## Test plan

- [x] Local version script runs successfully
- [x] `/health` endpoint returns correct version in local dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)