### PR TITLE
Address PR review recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,6 +810,8 @@ curl -X POST "http://127.0.0.1:8787/proxy/getAccessToken?code=AUTH_CODE&redirect
 
 When both are provided, POST body parameters take priority over query string parameters.
 
+**Note:** When using POST body (`application/x-www-form-urlencoded`), the `Content-Length` header is required. Requests without it receive a `411 Length Required` response. The POST body is limited to 10KB (OAuth parameters are typically under 1KB). Standard HTTP clients and browsers always include `Content-Length` automatically.
+
 ## Version Management
 
 This project uses Husky to automatically increment the patch version in each subfolder's `package.json` when files in that subfolder are committed.

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/scripts/deploy.js
+++ b/proxy/scripts/deploy.js
@@ -12,6 +12,7 @@
 
 import { execSync } from 'child_process'
 import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'fs'
+import { tmpdir } from 'os'
 import { config } from 'dotenv'
 import { fileURLToPath } from 'url'
 import { dirname, join } from 'path'
@@ -214,7 +215,7 @@ if (namespaceMatch) {
     console.warn('Warning: Invalid namespace ID format, skipping version storage')
   } else {
     // Write version to temp file to avoid shell injection of versionString
-    const tmpVersionFile = join(projectRoot, '.deploy-version.tmp')
+    const tmpVersionFile = join(tmpdir(), `deploy-version-${Date.now()}.tmp`)
     try {
       writeFileSync(tmpVersionFile, versionString)
       execSync(
@@ -227,7 +228,11 @@ if (namespaceMatch) {
     } catch (error) {
       console.warn('Warning: Failed to store deploy version')
     } finally {
-      try { unlinkSync(tmpVersionFile) } catch {}
+      try {
+        unlinkSync(tmpVersionFile)
+      } catch (cleanupError) {
+        console.warn(`Warning: Failed to clean up temp file ${tmpVersionFile}: ${cleanupError.message}`)
+      }
     }
   }
 }

--- a/proxy/scripts/deploy.js
+++ b/proxy/scripts/deploy.js
@@ -215,7 +215,7 @@ if (namespaceMatch) {
     console.warn('Warning: Invalid namespace ID format, skipping version storage')
   } else {
     // Write version to temp file to avoid shell injection of versionString
-    const tmpVersionFile = join(tmpdir(), `deploy-version-${Date.now()}.tmp`)
+    const tmpVersionFile = join(tmpdir(), `deploy-version-${process.pid}-${Date.now()}.tmp`)
     try {
       writeFileSync(tmpVersionFile, versionString)
       execSync(

--- a/proxy/scripts/deploy.js
+++ b/proxy/scripts/deploy.js
@@ -11,6 +11,7 @@
  */
 
 import { execSync } from 'child_process'
+import { randomUUID } from 'crypto'
 import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'fs'
 import { tmpdir } from 'os'
 import { config } from 'dotenv'
@@ -215,7 +216,7 @@ if (namespaceMatch) {
     console.warn('Warning: Invalid namespace ID format, skipping version storage')
   } else {
     // Write version to temp file to avoid shell injection of versionString
-    const tmpVersionFile = join(tmpdir(), `deploy-version-${process.pid}-${Date.now()}.tmp`)
+    const tmpVersionFile = join(tmpdir(), `deploy-version-${randomUUID()}.tmp`)
     try {
       writeFileSync(tmpVersionFile, versionString)
       execSync(

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -408,16 +408,20 @@ async function handleGetAccessToken(url, request, env) {
   // Parse POST body parameters if Content-Type is form-urlencoded
   let bodyParams = null
   try {
-    // Reject oversized POST bodies; Cloudflare Workers also enforces hard limits
-    const contentLength = parseInt(request.headers.get('Content-Length') || '0', 10)
-    if (isNaN(contentLength) || contentLength < 0 || contentLength > MAX_POST_BODY_SIZE) {
-      return jsonResponse({ error: 'Invalid or oversized request body' }, 413)
-    }
     const contentType = (request.headers.get('Content-Type') || '').toLowerCase()
     if (contentType.startsWith('application/x-www-form-urlencoded')) {
+      // Require Content-Length header to prevent DoS via unbounded body reads
+      const rawContentLength = request.headers.get('Content-Length')
+      if (rawContentLength === null) {
+        return jsonResponse({ error: 'Content-Length header required' }, 411)
+      }
+      const contentLength = parseInt(rawContentLength, 10)
+      if (isNaN(contentLength) || contentLength < 0 || contentLength > MAX_POST_BODY_SIZE) {
+        return jsonResponse({ error: 'Invalid or oversized request body' }, 413)
+      }
       // Note: request.text() consumes the body stream (single-read only)
       const bodyText = await request.text()
-      // Validate actual body size (Content-Length header can be omitted or mismatched)
+      // Validate actual body size in case Content-Length is mismatched
       if (bodyText.length > MAX_POST_BODY_SIZE) {
         return jsonResponse({ error: 'Invalid or oversized request body' }, 413)
       }

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -400,6 +400,7 @@ async function handleGetAccessToken(url, request, env) {
   // Parse POST body parameters if Content-Type is form-urlencoded
   let bodyParams = null
   try {
+    // Reject oversized POST bodies (10KB limit; OAuth params should be <1KB)
     const contentLength = parseInt(request.headers.get('Content-Length') || '0', 10)
     if (contentLength > 10000) {
       return jsonResponse({ error: 'Request body too large' }, 413)

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -400,8 +400,12 @@ async function handleGetAccessToken(url, request, env) {
   // Parse POST body parameters if Content-Type is form-urlencoded
   let bodyParams = null
   try {
+    const contentLength = parseInt(request.headers.get('Content-Length') || '0', 10)
+    if (contentLength > 10000) {
+      return jsonResponse({ error: 'Request body too large' }, 413)
+    }
     const contentType = (request.headers.get('Content-Type') || '').toLowerCase()
-    if (contentType.includes('application/x-www-form-urlencoded')) {
+    if (contentType.startsWith('application/x-www-form-urlencoded')) {
       // Note: request.text() consumes the body stream (single-read only)
       const bodyText = await request.text()
       bodyParams = new URLSearchParams(bodyText)

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -42,6 +42,9 @@ const DEFAULT_RATE_LIMIT_ADMIN = 60 // requests per window
 const DEFAULT_RATE_LIMIT_WINDOW = 60 // seconds
 const DEFAULT_RATE_LIMIT_UNKNOWN = 5 // very restrictive limit for unidentified clients
 
+// Request body limits
+const MAX_POST_BODY_SIZE = 10000 // 10KB; OAuth params should be <1KB
+
 // SSRF protection constants
 const MAX_ALLOWED_DOMAINS_CONFIG_LENGTH = 1024 // Max length of ALLOWED_API_DOMAINS config string
 const MAX_DEBUG_LOG_VALUE_LENGTH = 100 // Max length for user-controlled values in debug logs
@@ -400,10 +403,10 @@ async function handleGetAccessToken(url, request, env) {
   // Parse POST body parameters if Content-Type is form-urlencoded
   let bodyParams = null
   try {
-    // Reject oversized POST bodies (10KB limit; OAuth params should be <1KB)
+    // Reject oversized POST bodies; Cloudflare Workers also enforces hard limits
     const contentLength = parseInt(request.headers.get('Content-Length') || '0', 10)
-    if (contentLength > 10000) {
-      return jsonResponse({ error: 'Request body too large' }, 413)
+    if (isNaN(contentLength) || contentLength < 0 || contentLength > MAX_POST_BODY_SIZE) {
+      return jsonResponse({ error: 'Invalid or oversized request body' }, 413)
     }
     const contentType = (request.headers.get('Content-Type') || '').toLowerCase()
     if (contentType.startsWith('application/x-www-form-urlencoded')) {

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -400,14 +400,15 @@ async function handleGetAccessToken(url, request, env) {
   // Parse POST body parameters if Content-Type is form-urlencoded
   let bodyParams = null
   try {
-    const contentType = request.headers.get('Content-Type') || ''
+    const contentType = (request.headers.get('Content-Type') || '').toLowerCase()
     if (contentType.includes('application/x-www-form-urlencoded')) {
+      // Note: request.text() consumes the body stream (single-read only)
       const bodyText = await request.text()
       bodyParams = new URLSearchParams(bodyText)
     }
-  } catch {
+  } catch (error) {
     // Malformed body - fall through to query string params
-    debugLog(env, 'Failed to parse request body, falling back to query params')
+    debugLog(env, `Failed to parse request body (${error.message}), falling back to query params`)
   }
 
   // Body params take priority, fall back to query string

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -408,7 +408,7 @@ async function handleGetAccessToken(url, request, env) {
   // Parse POST body parameters if Content-Type is form-urlencoded
   let bodyParams = null
   try {
-    const contentType = (request.headers.get('Content-Type') || '').toLowerCase()
+    const contentType = (request.headers.get('Content-Type') || '').toLowerCase().trim()
     if (contentType.startsWith('application/x-www-form-urlencoded')) {
       // Require Content-Length header to prevent DoS via unbounded body reads
       const rawContentLength = request.headers.get('Content-Length')

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -42,8 +42,13 @@ const DEFAULT_RATE_LIMIT_ADMIN = 60 // requests per window
 const DEFAULT_RATE_LIMIT_WINDOW = 60 // seconds
 const DEFAULT_RATE_LIMIT_UNKNOWN = 5 // very restrictive limit for unidentified clients
 
-// Request body limits
-const MAX_POST_BODY_SIZE = 10000 // 10KB; OAuth params should be <1KB
+/**
+ * Maximum allowed POST body size in bytes for token exchange requests.
+ * OAuth parameters (code + redirect_uri) should be well under 1KB.
+ * This limit prevents DoS via oversized payloads. Cloudflare Workers
+ * also enforces its own hard request size limits (~100MB paid, ~10MB free).
+ */
+const MAX_POST_BODY_SIZE = 10000
 
 // SSRF protection constants
 const MAX_ALLOWED_DOMAINS_CONFIG_LENGTH = 1024 // Max length of ALLOWED_API_DOMAINS config string
@@ -412,6 +417,10 @@ async function handleGetAccessToken(url, request, env) {
     if (contentType.startsWith('application/x-www-form-urlencoded')) {
       // Note: request.text() consumes the body stream (single-read only)
       const bodyText = await request.text()
+      // Validate actual body size (Content-Length header can be omitted or mismatched)
+      if (bodyText.length > MAX_POST_BODY_SIZE) {
+        return jsonResponse({ error: 'Invalid or oversized request body' }, 413)
+      }
       bodyParams = new URLSearchParams(bodyText)
     }
   } catch (error) {

--- a/proxy/test/oauth.test.js
+++ b/proxy/test/oauth.test.js
@@ -105,6 +105,20 @@ describe('OAuth endpoints', () => {
       expect(response.status).not.toBe(400)
     })
 
+    it('should accept Content-Type with charset parameter', async () => {
+      const response = await fetchWithMetrics('http://localhost/proxy/getAccessToken', {
+        method: 'POST',
+        headers: {
+          Origin: 'http://localhost:5173',
+          'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'
+        },
+        body: 'code=test-code&redirect_uri=http://localhost:5173'
+      })
+
+      // Should not be 400 (missing params) - charset is valid Content-Type parameter
+      expect(response.status).not.toBe(400)
+    })
+
     it('should fall back to query string when no Content-Type header set', async () => {
       const response = await fetchWithMetrics(
         'http://localhost/proxy/getAccessToken?code=test-code&redirect_uri=http://localhost:5173',

--- a/proxy/test/security.test.js
+++ b/proxy/test/security.test.js
@@ -663,6 +663,47 @@ describe('Security - POST Body Input Validation', () => {
     expect(data.error).toContain('Invalid')
   })
 
+  it('should accept POST body with Content-Length of 0', async () => {
+    // Content-Length: 0 is valid; body will be empty so params fall back to query string
+    const response = await fetchWithMetrics(
+      'http://localhost/proxy/getAccessToken?code=test&redirect_uri=http://localhost:5173',
+      {
+        method: 'POST',
+        headers: {
+          Origin: 'http://localhost:5173',
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Content-Length': '0'
+        },
+        body: ''
+      }
+    )
+
+    // Should not be 413 - Content-Length 0 is valid
+    expect(response.status).not.toBe(413)
+    expect(response.status).not.toBe(411)
+  })
+
+  it('should reject POST body with extremely large Content-Length string', async () => {
+    // parseInt of a number exceeding MAX_SAFE_INTEGER; parsed as a large finite number
+    const response = await fetchWithMetrics('http://localhost/proxy/getAccessToken', {
+      method: 'POST',
+      headers: {
+        Origin: 'http://localhost:5173',
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Length': '99999999999999999999999'
+      },
+      body: 'code=test&redirect_uri=http://localhost:5173'
+    })
+
+    expect(response.status).toBe(413)
+    const data = await response.json()
+    expect(data.error).toContain('oversized')
+  })
+
+  // Note: Testing missing Content-Length → 411 is not possible in Miniflare/fetch
+  // because fetch() auto-adds Content-Length when a body is present. The 411 code
+  // path protects against raw HTTP clients that omit the header.
+
   it('should reject oversized actual body even with small Content-Length header', async () => {
     // Tests the bodyText.length check that catches Content-Length mismatch.
     // Note: fetch() auto-sets Content-Length to match body, so we set it explicitly

--- a/proxy/test/security.test.js
+++ b/proxy/test/security.test.js
@@ -613,7 +613,54 @@ describe('Security - POST Body Input Validation', () => {
 
     expect(response.status).toBe(413)
     const data = await response.json()
-    expect(data.error).toContain('too large')
+    expect(data.error).toContain('oversized')
+  })
+
+  it('should accept POST body with Content-Length exactly 10000', async () => {
+    const response = await fetchWithMetrics('http://localhost/proxy/getAccessToken', {
+      method: 'POST',
+      headers: {
+        Origin: 'http://localhost:5173',
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Length': '10000'
+      },
+      body: 'code=test&redirect_uri=http://localhost:5173'
+    })
+
+    // Should not be 413 - exactly at the limit is allowed
+    expect(response.status).not.toBe(413)
+  })
+
+  it('should reject POST body with non-numeric Content-Length', async () => {
+    const response = await fetchWithMetrics('http://localhost/proxy/getAccessToken', {
+      method: 'POST',
+      headers: {
+        Origin: 'http://localhost:5173',
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Length': 'garbage'
+      },
+      body: 'code=test&redirect_uri=http://localhost:5173'
+    })
+
+    expect(response.status).toBe(413)
+    const data = await response.json()
+    expect(data.error).toContain('Invalid')
+  })
+
+  it('should reject POST body with negative Content-Length', async () => {
+    const response = await fetchWithMetrics('http://localhost/proxy/getAccessToken', {
+      method: 'POST',
+      headers: {
+        Origin: 'http://localhost:5173',
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Length': '-100'
+      },
+      body: 'code=test&redirect_uri=http://localhost:5173'
+    })
+
+    expect(response.status).toBe(413)
+    const data = await response.json()
+    expect(data.error).toContain('Invalid')
   })
 
   it('should fall back to query params when POST body is malformed', async () => {

--- a/proxy/test/security.test.js
+++ b/proxy/test/security.test.js
@@ -663,19 +663,24 @@ describe('Security - POST Body Input Validation', () => {
     expect(data.error).toContain('Invalid')
   })
 
-  it('should accept POST body with missing Content-Length header', async () => {
+  it('should reject oversized actual body even with small Content-Length header', async () => {
+    // Tests the bodyText.length check that catches Content-Length mismatch.
+    // Note: fetch() auto-sets Content-Length to match body, so we set it explicitly
+    // to simulate a mismatch (e.g. from a raw HTTP client).
+    const largeBody = 'code=test&redirect_uri=' + 'x'.repeat(10001)
     const response = await fetchWithMetrics('http://localhost/proxy/getAccessToken', {
       method: 'POST',
       headers: {
         Origin: 'http://localhost:5173',
-        'Content-Type': 'application/x-www-form-urlencoded'
-        // Content-Length intentionally omitted
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Length': '50'
       },
-      body: 'code=test&redirect_uri=http://localhost:5173'
+      body: largeBody
     })
 
-    // Should work - small body defaults to Content-Length 0 which passes header check
-    expect(response.status).not.toBe(413)
+    expect(response.status).toBe(413)
+    const data = await response.json()
+    expect(data.error).toContain('oversized')
   })
 
   it('should fall back to query params when POST body is malformed', async () => {

--- a/proxy/test/security.test.js
+++ b/proxy/test/security.test.js
@@ -663,6 +663,21 @@ describe('Security - POST Body Input Validation', () => {
     expect(data.error).toContain('Invalid')
   })
 
+  it('should accept POST body with missing Content-Length header', async () => {
+    const response = await fetchWithMetrics('http://localhost/proxy/getAccessToken', {
+      method: 'POST',
+      headers: {
+        Origin: 'http://localhost:5173',
+        'Content-Type': 'application/x-www-form-urlencoded'
+        // Content-Length intentionally omitted
+      },
+      body: 'code=test&redirect_uri=http://localhost:5173'
+    })
+
+    // Should work - small body defaults to Content-Length 0 which passes header check
+    expect(response.status).not.toBe(413)
+  })
+
   it('should fall back to query params when POST body is malformed', async () => {
     const response = await fetchWithMetrics(
       'http://localhost/proxy/getAccessToken?code=test&redirect_uri=http://localhost:5173',

--- a/proxy/test/security.test.js
+++ b/proxy/test/security.test.js
@@ -600,6 +600,22 @@ describe('Security - POST Body Input Validation', () => {
     expect(data.error).toContain('domain not allowed')
   })
 
+  it('should reject POST body with Content-Length > 10000', async () => {
+    const response = await fetchWithMetrics('http://localhost/proxy/getAccessToken', {
+      method: 'POST',
+      headers: {
+        Origin: 'http://localhost:5173',
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Length': '10001'
+      },
+      body: 'code=test&redirect_uri=http://localhost:5173'
+    })
+
+    expect(response.status).toBe(413)
+    const data = await response.json()
+    expect(data.error).toContain('too large')
+  })
+
   it('should fall back to query params when POST body is malformed', async () => {
     const response = await fetchWithMetrics(
       'http://localhost/proxy/getAccessToken?code=test&redirect_uri=http://localhost:5173',


### PR DESCRIPTION
## Summary

Addresses review recommendations from PR #98:

- **Capture error in catch block** (`proxy/src/index.js`): Log `error.message` instead of bare `catch {}`
- **Case-insensitive Content-Type check** (`proxy/src/index.js`): Apply `.toLowerCase()` before `.includes()`
- **Document body stream consumption**: Added comment that `request.text()` is single-read
- **Use OS temp directory** (`proxy/scripts/deploy.js`): Temp file now written to `os.tmpdir()` with timestamp to avoid project root clutter
- **Log cleanup failures** (`proxy/scripts/deploy.js`): Temp file cleanup errors are now logged instead of silently ignored

## Versions

| Package | Version |
|---------|---------|
| proxy   | 1.3.2   |

## Test Results

| Suite | Result |
|-------|--------|
| Proxy (Vitest) | 12 files, 353 tests passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)