### PR TITLE
Security fixes: CI/CD injection, refresh race condition, CSP hardening

### DIFF
--- a/.github/workflows/check-proxy-version.yml
+++ b/.github/workflows/check-proxy-version.yml
@@ -84,9 +84,10 @@ jobs:
           echo "Parsed deployed version: $DEPLOYED_VERSION"
 
       - name: Compare and Warn
+        env:
+          PR_VER: ${{ steps.pr_version.outputs.version }}
+          DEP_VER: ${{ steps.deployed_version.outputs.deployed_version }}
         run: |
-          PR_VER="${{ steps.pr_version.outputs.version }}"
-          DEP_VER="${{ steps.deployed_version.outputs.deployed_version }}"
           
           echo "Comparing PR version ($PR_VER) with Deployed version ($DEP_VER)"
           

--- a/.github/workflows/pr-review-gemini.yml
+++ b/.github/workflows/pr-review-gemini.yml
@@ -31,9 +31,13 @@ jobs:
               echo "::error::claude-review.md exceeds ${MAX_SIZE} bytes (${FILE_SIZE} bytes). Please reduce file size to prevent instructions being cut off."
               exit 1
             fi
-            echo "extra_prompt<<EOF" >> $GITHUB_OUTPUT
+            DELIMITER="GHOUTPUT_$(openssl rand -hex 8)"
+            while grep -qF "$DELIMITER" "$PROMPT_FILE" 2>/dev/null; do
+              DELIMITER="GHOUTPUT_$(openssl rand -hex 8)"
+            done
+            echo "extra_prompt<<${DELIMITER}" >> $GITHUB_OUTPUT
             cat "$PROMPT_FILE" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
+            echo "${DELIMITER}" >> $GITHUB_OUTPUT
           else
             # No custom prompts file found - continue with default prompts only
             echo "extra_prompt=" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -31,9 +31,13 @@ jobs:
               echo "::error::claude-review.md exceeds ${MAX_SIZE} bytes (${FILE_SIZE} bytes). Please reduce file size to prevent instructions being cut off."
               exit 1
             fi
-            echo "extra_prompt<<EOF" >> $GITHUB_OUTPUT
+            DELIMITER="GHOUTPUT_$(openssl rand -hex 8)"
+            while grep -qF "$DELIMITER" "$PROMPT_FILE" 2>/dev/null; do
+              DELIMITER="GHOUTPUT_$(openssl rand -hex 8)"
+            done
+            echo "extra_prompt<<${DELIMITER}" >> $GITHUB_OUTPUT
             cat "$PROMPT_FILE" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
+            echo "${DELIMITER}" >> $GITHUB_OUTPUT
           else
             # No custom prompts file found - continue with default prompts only
             echo "extra_prompt=" >> $GITHUB_OUTPUT
@@ -60,11 +64,13 @@ jobs:
 
       - name: Extract and Post Review Comment
         uses: actions/github-script@v7
+        env:
+          EXEC_FILE: ${{ steps.claude-review.outputs.execution_file }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            const execFile = '${{ steps.claude-review.outputs.execution_file }}';
+            const execFile = process.env.EXEC_FILE;
 
             // Extract the last assistant text from conversation turns
             // Uses reverse iteration with early break for better performance

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-admin",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-admin",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-admin",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-admin",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-admin",
   "displayName": "EEN OAuth Proxy Admin",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-admin",
   "displayName": "EEN OAuth Proxy Admin",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/admin/src/stores/auth.js
+++ b/admin/src/stores/auth.js
@@ -44,6 +44,18 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
+  // Allowed EEN API domains — hostname must end with one of these
+  const ALLOWED_EEN_DOMAINS = ['.eagleeyenetworks.com', '.een.cloud']
+
+  /** Returns true if hostname is a valid EEN API domain */
+  function isAllowedEenHostname(h) {
+    if (!h || typeof h !== 'string') return false
+    const lower = h.toLowerCase()
+    // Block non-ASCII and whitespace
+    if (!/^[a-z0-9.-]+$/.test(lower)) return false
+    return ALLOWED_EEN_DOMAINS.some((d) => lower.endsWith(d))
+  }
+
   // Actions
   function initialize() {
     try {
@@ -69,9 +81,15 @@ export const useAuthStore = defineStore('auth', () => {
         sessionId.value = storedSessionId
       }
       if (storedHostname) {
-        hostname.value = storedHostname
+        if (isAllowedEenHostname(storedHostname)) {
+          hostname.value = storedHostname
+        } else {
+          console.warn('[Auth] Blocked invalid hostname from localStorage:', storedHostname)
+          safeRemoveItem('hostname')
+          safeRemoveItem('port')
+        }
       }
-      if (storedPort) {
+      if (storedPort && hostname.value) {
         port.value = parseInt(storedPort, 10)
       }
       if (storedProfile) {
@@ -137,7 +155,12 @@ export const useAuthStore = defineStore('auth', () => {
 
   function setBaseUrl(data) {
     if (data) {
-      hostname.value = data.hostname || data
+      const newHostname = data.hostname || data
+      if (!isAllowedEenHostname(newHostname)) {
+        console.warn('[Auth] Blocked invalid EEN hostname:', newHostname)
+        return
+      }
+      hostname.value = newHostname
       port.value = data.port || 443
 
   safeSetItem('hostname', hostname.value)

--- a/admin/vite-plugin-csp.js
+++ b/admin/vite-plugin-csp.js
@@ -9,12 +9,14 @@ import { loadEnv } from 'vite'
  * - localhost (for dev)
  * - VITE_PROXY_URL (configured proxy)
  * 
- * We always include localhost for dev compatibility, and add VITE_PROXY_URL
- * if it's different from localhost.
+ * In development, we include localhost for dev compatibility.
+ * In production, localhost is excluded. VITE_PROXY_URL is added if it's
+ * not already in the list and not a localhost variant.
  */
 export function cspPlugin() {
   let proxyUrl = 'http://localhost:8787'
   let configInitialized = false
+  let buildMode = 'development'
   
   return {
     name: 'csp-plugin',
@@ -32,6 +34,7 @@ export function cspPlugin() {
         // Load environment variables based on Vite's mode
         const env = loadEnv(mode, process.cwd(), 'VITE_')
         proxyUrl = env.VITE_PROXY_URL || 'http://localhost:8787'
+        buildMode = mode
         configInitialized = true
       } catch (error) {
         console.warn(`CSP plugin: Failed to load environment variables for mode "${mode}":`, error.message)
@@ -45,16 +48,19 @@ export function cspPlugin() {
         console.warn('CSP plugin: transformIndexHtml called before configResolved, using default proxy URL')
       }
       
-      // Build connect-src directive - always include localhost for dev compatibility
-      // Users can select between localhost and VITE_PROXY_URL at runtime,
-      // so we need both in the CSP
+      // Build connect-src directive
+      // In development, include localhost for dev compatibility
+      // In production, exclude localhost origins
       const connectSrcParts = [
         "'self'",
-        'http://localhost:8787',
-        'http://127.0.0.1:8787',
         'https://auth.eagleeyenetworks.com',
         'https://*.eagleeyenetworks.com'
       ]
+
+      // Only include localhost origins in non-production builds
+      if (buildMode !== 'production') {
+        connectSrcParts.splice(1, 0, 'http://localhost:8787', 'http://127.0.0.1:8787')
+      }
       
       // Add the proxy URL if it's not already in the list (and not localhost)
       // Use URL parsing for precise hostname matching to avoid false positives

--- a/demo1/package-lock.json
+++ b/demo1/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-demo1",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-demo1",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/demo1/package-lock.json
+++ b/demo1/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-demo1",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-demo1",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/demo1/package.json
+++ b/demo1/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-demo1",
   "displayName": "EEN OAuth Demo1",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/demo1/package.json
+++ b/demo1/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-demo1",
   "displayName": "EEN OAuth Demo1",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/demo1/src/stores/auth.js
+++ b/demo1/src/stores/auth.js
@@ -42,6 +42,18 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
+  // Allowed EEN API domains — hostname must end with one of these
+  const ALLOWED_EEN_DOMAINS = ['.eagleeyenetworks.com', '.een.cloud']
+
+  /** Returns true if hostname is a valid EEN API domain */
+  function isAllowedEenHostname(h) {
+    if (!h || typeof h !== 'string') return false
+    const lower = h.toLowerCase()
+    // Block non-ASCII and whitespace
+    if (!/^[a-z0-9.-]+$/.test(lower)) return false
+    return ALLOWED_EEN_DOMAINS.some((d) => lower.endsWith(d))
+  }
+
   // Actions
   function initialize() {
     try {
@@ -67,9 +79,15 @@ export const useAuthStore = defineStore('auth', () => {
         sessionId.value = storedSessionId
       }
       if (storedHostname) {
-        hostname.value = storedHostname
+        if (isAllowedEenHostname(storedHostname)) {
+          hostname.value = storedHostname
+        } else {
+          console.warn('[Auth] Blocked invalid hostname from localStorage:', storedHostname)
+          safeRemoveItem('hostname')
+          safeRemoveItem('port')
+        }
       }
-      if (storedPort) {
+      if (storedPort && hostname.value) {
         port.value = parseInt(storedPort, 10)
       }
       if (storedProfile) {
@@ -134,7 +152,12 @@ export const useAuthStore = defineStore('auth', () => {
 
   function setBaseUrl(data) {
     if (data) {
-      hostname.value = data.hostname || data
+      const newHostname = data.hostname || data
+      if (!isAllowedEenHostname(newHostname)) {
+        console.warn('[Auth] Blocked invalid EEN hostname:', newHostname)
+        return
+      }
+      hostname.value = newHostname
       port.value = data.port || 443
 
       safeSetItem('hostname', hostname.value)

--- a/demo1/vite-plugin-csp.js
+++ b/demo1/vite-plugin-csp.js
@@ -9,12 +9,14 @@ import { loadEnv } from 'vite'
  * - localhost (for dev)
  * - VITE_PROXY_URL (configured proxy)
  * 
- * We always include localhost for dev compatibility, and add VITE_PROXY_URL
- * if it's different from localhost.
+ * In development, we include localhost for dev compatibility.
+ * In production, localhost is excluded. VITE_PROXY_URL is added if it's
+ * not already in the list and not a localhost variant.
  */
 export function cspPlugin() {
   let proxyUrl = 'http://localhost:8787'
   let configInitialized = false
+  let buildMode = 'development'
   
   return {
     name: 'csp-plugin',
@@ -32,6 +34,7 @@ export function cspPlugin() {
         // Load environment variables based on Vite's mode
         const env = loadEnv(mode, process.cwd(), 'VITE_')
         proxyUrl = env.VITE_PROXY_URL || 'http://localhost:8787'
+        buildMode = mode
         configInitialized = true
       } catch (error) {
         console.warn(`CSP plugin: Failed to load environment variables for mode "${mode}":`, error.message)
@@ -45,16 +48,19 @@ export function cspPlugin() {
         console.warn('CSP plugin: transformIndexHtml called before configResolved, using default proxy URL')
       }
       
-      // Build connect-src directive - always include localhost for dev compatibility
-      // Users can select between localhost and VITE_PROXY_URL at runtime,
-      // so we need both in the CSP
+      // Build connect-src directive
+      // In development, include localhost for dev compatibility
+      // In production, exclude localhost origins
       const connectSrcParts = [
         "'self'",
-        'http://localhost:8787',
-        'http://127.0.0.1:8787',
         'https://auth.eagleeyenetworks.com',
         'https://*.eagleeyenetworks.com'
       ]
+
+      // Only include localhost origins in non-production builds
+      if (buildMode !== 'production') {
+        connectSrcParts.splice(1, 0, 'http://localhost:8787', 'http://127.0.0.1:8787')
+      }
       
       // Add the proxy URL if it's not already in the list (and not localhost)
       // Use URL parsing for precise hostname matching to avoid false positives

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.3.8",
+      "version": "1.3.9",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -585,8 +585,15 @@ async function handleRefreshAccessToken(request, env) {
   if (!tokenResponse.ok) {
     const errorText = await tokenResponse.text()
     debugError(env, 'EEN refresh error:', errorText)
-    // Clear invalid session
-    await env.EEN_OAUTH_SESSIONS.delete(sessionId)
+    // Re-read session to check for concurrent refresh
+    const currentSessionStr = await env.EEN_OAUTH_SESSIONS.get(sessionId)
+    if (currentSessionStr) {
+      const currentSession = JSON.parse(currentSessionStr)
+      // Only delete if refresh token hasn't been updated by a concurrent request
+      if (currentSession.refreshToken === sessionData.refreshToken) {
+        await env.EEN_OAUTH_SESSIONS.delete(sessionId)
+      }
+    }
     return jsonResponse({ error: 'Token refresh failed' }, tokenResponse.status)
   }
 


### PR DESCRIPTION
## Summary
- **HIGH**: Fix expression injection in `pr-review.yml` — pass `execution_file` via `env:` instead of `${{ }}` interpolation in script block
- **HIGH**: Fix shell injection in `check-proxy-version.yml` — pass version outputs via `env:` instead of `${{ }}` in `run:` block
- **MEDIUM**: Replace hardcoded `EOF` delimiter with random delimiter + collision check in `pr-review.yml` and `pr-review-gemini.yml`
- **MEDIUM**: Fix refresh token race condition in proxy — re-read session from KV before deleting on refresh failure to avoid destroying concurrently-updated sessions
- **LOW**: Exclude `localhost` and `127.0.0.1` origins from CSP `connect-src` in production builds for admin and demo1

## Test plan
- [x] Proxy API tests: 361/361 passed
- [x] Admin unit tests: 43/43 passed (including 16 CSP plugin tests)
- [x] Demo1 E2E tests: passed
- [x] Admin/demo1 production builds verified — no localhost in CSP `connect-src`
- [ ] Verify CI workflow YAML syntax in PR checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)