### PR TITLE
Fix security findings: refresh race, KV pagination, rate limit bypass

### DIFF
--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.3.10",
+      "version": "1.3.11",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.3.11",
+      "version": "1.3.12",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.3.12",
+      "version": "1.3.13",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.3.9",
+      "version": "1.3.10",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -118,6 +118,29 @@ function getRefreshTokenTtl(env) {
 }
 
 /**
+ * List all KV keys, paginating through results if there are more than 1000.
+ * Cloudflare KV .list() returns at most 1000 keys per call.
+ * @param {Object} kvNamespace - Cloudflare KV namespace binding
+ * @param {Object} [options] - Options passed to KV .list() (e.g. { prefix: '...' })
+ * @returns {Promise<Array<{name: string}>>} - All matching keys
+ */
+async function listAllKVKeys(kvNamespace, options = {}) {
+  const allKeys = []
+  let cursor = undefined
+  const MAX_KEYS = 100000 // Safety cap
+
+  do {
+    const listOpts = { ...options }
+    if (cursor) listOpts.cursor = cursor
+    const result = await kvNamespace.list(listOpts)
+    allKeys.push(...result.keys)
+    cursor = result.list_complete ? undefined : result.cursor
+  } while (cursor && allKeys.length < MAX_KEYS)
+
+  return allKeys
+}
+
+/**
  * Validates that a URL is a legitimate API endpoint based on configured allowlist.
  * Prevents SSRF attacks by only allowing configured domains.
  * @param {string} url - The URL to validate
@@ -318,18 +341,12 @@ export default {
 
     // Handle CORS preflight (after rate limit check)
     if (request.method === 'OPTIONS') {
-      // Increment rate limit counter for OPTIONS requests too
-      ctx.waitUntil(incrementRateLimitCounter(request, url, env))
       return handleCorsPreflightRequest(corsResult.origin, env)
     }
 
     try {
       // Route requests
       const response = await routeRequest(url, request, env)
-
-      // Increment rate limit counter for all requests including 404s
-      // This prevents endpoint enumeration attacks where attackers probe for valid paths
-      ctx.waitUntil(incrementRateLimitCounter(request, url, env))
 
       return addCorsHeaders(response, corsResult.origin, env)
     } catch (error) {
@@ -585,15 +602,9 @@ async function handleRefreshAccessToken(request, env) {
   if (!tokenResponse.ok) {
     const errorText = await tokenResponse.text()
     debugError(env, 'EEN refresh error:', errorText)
-    // Re-read session to check for concurrent refresh
-    const currentSessionStr = await env.EEN_OAUTH_SESSIONS.get(sessionId)
-    if (currentSessionStr) {
-      const currentSession = JSON.parse(currentSessionStr)
-      // Only delete if refresh token hasn't been updated by a concurrent request
-      if (currentSession.refreshToken === sessionData.refreshToken) {
-        await env.EEN_OAUTH_SESSIONS.delete(sessionId)
-      }
-    }
+    // Don't delete session on refresh failure — let TTL handle expiration.
+    // Avoids race condition where concurrent successful refresh wrote a new
+    // token but KV eventual consistency returns stale data on re-read.
     return jsonResponse({ error: 'Token refresh failed' }, tokenResponse.status)
   }
 
@@ -733,10 +744,10 @@ async function handleAdminSessionsCount(request, env) {
     return jsonResponse({ error: adminCheck.error }, adminCheck.status)
   }
 
-  const listResult = await env.EEN_OAUTH_SESSIONS.list()
+  const keys = await listAllKVKeys(env.EEN_OAUTH_SESSIONS)
 
   // Filter out special keys (DEPLOY_* and RATE_LIMIT:*)
-  const sessionKeys = listResult.keys.filter(
+  const sessionKeys = keys.filter(
     key => !key.name.startsWith('DEPLOY_') && !key.name.startsWith('RATE_LIMIT:')
   )
 
@@ -757,10 +768,10 @@ async function handleAdminRemoveSessions(request, env) {
   }
 
   const currentSessionId = getSessionId(request, env)
-  const listResult = await env.EEN_OAUTH_SESSIONS.list()
+  const keys = await listAllKVKeys(env.EEN_OAUTH_SESSIONS)
 
   let deletedCount = 0
-  for (const key of listResult.keys) {
+  for (const key of keys) {
     // Skip current session and special keys (DEPLOY_* and RATE_LIMIT:*)
     if (
       key.name === currentSessionId ||
@@ -793,12 +804,12 @@ async function handleAdminRevokeAll(request, env) {
   }
 
   const currentSessionId = getSessionId(request, env)
-  const listResult = await env.EEN_OAUTH_SESSIONS.list()
+  const keys = await listAllKVKeys(env.EEN_OAUTH_SESSIONS)
 
   let revokedCount = 0
   let errorCount = 0
 
-  for (const key of listResult.keys) {
+  for (const key of keys) {
     // Skip special keys (DEPLOY_* and RATE_LIMIT:*)
     if (key.name.startsWith('DEPLOY_') || key.name.startsWith('RATE_LIMIT:')) {
       continue
@@ -952,7 +963,9 @@ function getRateLimitKey(category, identifier, window) {
 }
 
 /**
- * Check if request is rate limited
+ * Check if request is rate limited. If not limited, synchronously increments
+ * the counter before returning to prevent concurrent request bursts from
+ * bypassing the limit.
  * Note: Counter increments are non-atomic due to KV's eventual consistency.
  * This means under high concurrency, some requests may slip through slightly
  * over the limit. This is acceptable for rate limiting purposes - the goal
@@ -1002,50 +1015,17 @@ async function checkRateLimit(request, url, env) {
 
       return { limited: true, retryAfter: Math.max(1, retryAfter) }
     }
+
+    // Increment counter synchronously before returning
+    await env.EEN_OAUTH_SESSIONS.put(key, String(count + 1), {
+      expirationTtl: config.window * 2
+    })
   } catch (e) {
     // If KV fails, allow the request (fail open)
     debugError(env, 'Rate limit check failed:', e)
   }
 
   return { limited: false }
-}
-
-/**
- * Increment rate limit counter for a request
- * @param {Request} request - Incoming request
- * @param {URL} url - Parsed URL
- * @param {Object} env - Environment bindings
- */
-async function incrementRateLimitCounter(request, url, env) {
-  const config = getRateLimitConfig(env)
-
-  // Skip if rate limiting is disabled
-  if (!config.enabled) {
-    return
-  }
-
-  const category = getRateLimitCategory(url.pathname)
-
-  // Skip if path is not rate limited
-  if (!category) {
-    return
-  }
-
-  const { identifier } = getClientIdentifier(request, env)
-  const key = getRateLimitKey(category, identifier, config.window)
-
-  try {
-    const countStr = await env.EEN_OAUTH_SESSIONS.get(key)
-    const count = countStr ? parseInt(countStr, 10) : 0
-
-    // Store with TTL of 2x window to ensure cleanup
-    await env.EEN_OAUTH_SESSIONS.put(key, String(count + 1), {
-      expirationTtl: config.window * 2
-    })
-  } catch (e) {
-    // If KV fails, just log and continue
-    debugError(env, 'Rate limit increment failed:', e)
-  }
 }
 
 /**
@@ -1061,8 +1041,8 @@ async function handleAdminRateLimitStats(request, env) {
 
   const config = getRateLimitConfig(env)
 
-  // Get current rate limit entries from KV
-  const listResult = await env.EEN_OAUTH_SESSIONS.list({ prefix: 'RATE_LIMIT:' })
+  // Get current rate limit entries from KV (paginated)
+  const rateLimitKeys = await listAllKVKeys(env.EEN_OAUTH_SESSIONS, { prefix: 'RATE_LIMIT:' })
 
   // Parse and aggregate stats
   const stats = {
@@ -1070,7 +1050,7 @@ async function handleAdminRateLimitStats(request, env) {
     window: config.window,
     limits: config.limits,
     currentBucket: Math.floor(Date.now() / (config.window * 1000)),
-    activeEntries: listResult.keys.length,
+    activeEntries: rateLimitKeys.length,
     byCategory: {
       [RATE_LIMIT_CATEGORY.HEALTH]: { count: 0, uniqueClients: 0 },
       [RATE_LIMIT_CATEGORY.OAUTH]: { count: 0, uniqueClients: 0 },
@@ -1085,7 +1065,7 @@ async function handleAdminRateLimitStats(request, env) {
     [RATE_LIMIT_CATEGORY.ADMIN]: new Set()
   }
 
-  for (const key of listResult.keys) {
+  for (const key of rateLimitKeys) {
     // Parse key format: RATE_LIMIT:{category}:{identifier}:{bucket}
     const parts = key.name.split(':')
     if (parts.length >= 4) {

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -121,15 +121,17 @@ function getRefreshTokenTtl(env) {
  * List all KV keys, paginating through results if there are more than 1000.
  * Cloudflare KV .list() returns at most 1000 keys per call.
  * Stops after MAX_KEYS (10,000) to prevent runaway loops and excessive memory
- * usage. This cap is hardcoded for now; see GitHub issue for making it configurable.
+ * usage. This proxy is not designed for high-traffic deployments with very large
+ * key counts. The cap is hardcoded; see GitHub issue #102 for making it configurable.
  * @param {Object} kvNamespace - Cloudflare KV namespace binding
  * @param {Object} [options] - Options passed to KV .list() (e.g. { prefix: '...' })
- * @returns {Promise<Array<{name: string}>>} - All matching keys (up to MAX_KEYS)
+ * @param {Object} [env] - Environment bindings (for warning log on truncation)
+ * @returns {Promise<{keys: Array<{name: string}>, truncated: boolean}>}
  */
-async function listAllKVKeys(kvNamespace, options = {}) {
+async function listAllKVKeys(kvNamespace, options = {}, env = null) {
   const allKeys = []
   let cursor = undefined
-  const MAX_KEYS = 10000 // Safety cap to prevent runaway pagination
+  const MAX_KEYS = 10000 // Safety cap — see issue #102
 
   do {
     const listOpts = { ...options }
@@ -139,7 +141,12 @@ async function listAllKVKeys(kvNamespace, options = {}) {
     cursor = result.list_complete ? undefined : result.cursor
   } while (cursor && allKeys.length < MAX_KEYS)
 
-  return allKeys
+  const truncated = allKeys.length >= MAX_KEYS && !!cursor
+  if (truncated && env) {
+    debugError(env, `listAllKVKeys truncated at ${MAX_KEYS} keys (prefix: ${options.prefix || 'none'})`)
+  }
+
+  return { keys: allKeys, truncated }
 }
 
 /**
@@ -746,7 +753,7 @@ async function handleAdminSessionsCount(request, env) {
     return jsonResponse({ error: adminCheck.error }, adminCheck.status)
   }
 
-  const keys = await listAllKVKeys(env.EEN_OAUTH_SESSIONS)
+  const { keys } = await listAllKVKeys(env.EEN_OAUTH_SESSIONS, {}, env)
 
   // Filter out special keys (DEPLOY_* and RATE_LIMIT:*)
   const sessionKeys = keys.filter(
@@ -770,7 +777,7 @@ async function handleAdminRemoveSessions(request, env) {
   }
 
   const currentSessionId = getSessionId(request, env)
-  const keys = await listAllKVKeys(env.EEN_OAUTH_SESSIONS)
+  const { keys } = await listAllKVKeys(env.EEN_OAUTH_SESSIONS, {}, env)
 
   let deletedCount = 0
   for (const key of keys) {
@@ -806,7 +813,7 @@ async function handleAdminRevokeAll(request, env) {
   }
 
   const currentSessionId = getSessionId(request, env)
-  const keys = await listAllKVKeys(env.EEN_OAUTH_SESSIONS)
+  const { keys } = await listAllKVKeys(env.EEN_OAUTH_SESSIONS, {}, env)
 
   let revokedCount = 0
   let errorCount = 0
@@ -966,12 +973,12 @@ function getRateLimitKey(category, identifier, window) {
 
 /**
  * Check if request is rate limited. If not limited, synchronously increments
- * the counter before returning to prevent concurrent request bursts from
- * bypassing the limit.
- * Note: Counter increments are non-atomic due to KV's eventual consistency.
- * This means under high concurrency, some requests may slip through slightly
- * over the limit. This is acceptable for rate limiting purposes - the goal
- * is protection against abuse, not precise counting.
+ * the counter before returning to reduce (not eliminate) concurrent burst bypass.
+ * The read-modify-write cycle is still non-atomic — two concurrent requests can
+ * both read the same count and each write count+1 instead of count+2. This means
+ * rate limits are approximate under high concurrency: some requests may slip
+ * through slightly over the limit. This is acceptable for abuse prevention —
+ * the goal is deterrence, not precise counting.
  * @param {Request} request - Incoming request
  * @param {URL} url - Parsed URL
  * @param {Object} env - Environment bindings
@@ -1044,7 +1051,7 @@ async function handleAdminRateLimitStats(request, env) {
   const config = getRateLimitConfig(env)
 
   // Get current rate limit entries from KV (paginated)
-  const rateLimitKeys = await listAllKVKeys(env.EEN_OAUTH_SESSIONS, { prefix: 'RATE_LIMIT:' })
+  const { keys: rateLimitKeys } = await listAllKVKeys(env.EEN_OAUTH_SESSIONS, { prefix: 'RATE_LIMIT:' }, env)
 
   // Parse and aggregate stats
   const stats = {

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -120,14 +120,16 @@ function getRefreshTokenTtl(env) {
 /**
  * List all KV keys, paginating through results if there are more than 1000.
  * Cloudflare KV .list() returns at most 1000 keys per call.
+ * Stops after MAX_KEYS (10,000) to prevent runaway loops and excessive memory
+ * usage. This cap is hardcoded for now; see GitHub issue for making it configurable.
  * @param {Object} kvNamespace - Cloudflare KV namespace binding
  * @param {Object} [options] - Options passed to KV .list() (e.g. { prefix: '...' })
- * @returns {Promise<Array<{name: string}>>} - All matching keys
+ * @returns {Promise<Array<{name: string}>>} - All matching keys (up to MAX_KEYS)
  */
 async function listAllKVKeys(kvNamespace, options = {}) {
   const allKeys = []
   let cursor = undefined
-  const MAX_KEYS = 100000 // Safety cap
+  const MAX_KEYS = 10000 // Safety cap to prevent runaway pagination
 
   do {
     const listOpts = { ...options }

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -753,7 +753,7 @@ async function handleAdminSessionsCount(request, env) {
     return jsonResponse({ error: adminCheck.error }, adminCheck.status)
   }
 
-  const { keys } = await listAllKVKeys(env.EEN_OAUTH_SESSIONS, {}, env)
+  const { keys, truncated } = await listAllKVKeys(env.EEN_OAUTH_SESSIONS, {}, env)
 
   // Filter out special keys (DEPLOY_* and RATE_LIMIT:*)
   const sessionKeys = keys.filter(
@@ -761,7 +761,8 @@ async function handleAdminSessionsCount(request, env) {
   )
 
   return jsonResponse({
-    sessionCount: sessionKeys.length
+    sessionCount: sessionKeys.length,
+    ...(truncated && { truncated })
   })
 }
 
@@ -777,7 +778,7 @@ async function handleAdminRemoveSessions(request, env) {
   }
 
   const currentSessionId = getSessionId(request, env)
-  const { keys } = await listAllKVKeys(env.EEN_OAUTH_SESSIONS, {}, env)
+  const { keys, truncated } = await listAllKVKeys(env.EEN_OAUTH_SESSIONS, {}, env)
 
   let deletedCount = 0
   for (const key of keys) {
@@ -797,7 +798,8 @@ async function handleAdminRemoveSessions(request, env) {
   return jsonResponse({
     message: 'Sessions removed successfully',
     deletedSessions: deletedCount,
-    remainingSessions: 1
+    remainingSessions: 1,
+    ...(truncated && { truncated })
   })
 }
 
@@ -813,7 +815,7 @@ async function handleAdminRevokeAll(request, env) {
   }
 
   const currentSessionId = getSessionId(request, env)
-  const { keys } = await listAllKVKeys(env.EEN_OAUTH_SESSIONS, {}, env)
+  const { keys, truncated } = await listAllKVKeys(env.EEN_OAUTH_SESSIONS, {}, env)
 
   let revokedCount = 0
   let errorCount = 0
@@ -856,7 +858,8 @@ async function handleAdminRevokeAll(request, env) {
   const response = jsonResponse({
     message: 'All tokens revoked',
     revokedSessions: revokedCount,
-    errors: errorCount
+    errors: errorCount,
+    ...(truncated && { truncated })
   })
 
   response.headers.append(
@@ -1051,7 +1054,7 @@ async function handleAdminRateLimitStats(request, env) {
   const config = getRateLimitConfig(env)
 
   // Get current rate limit entries from KV (paginated)
-  const { keys: rateLimitKeys } = await listAllKVKeys(env.EEN_OAUTH_SESSIONS, { prefix: 'RATE_LIMIT:' }, env)
+  const { keys: rateLimitKeys, truncated } = await listAllKVKeys(env.EEN_OAUTH_SESSIONS, { prefix: 'RATE_LIMIT:' }, env)
 
   // Parse and aggregate stats
   const stats = {
@@ -1109,6 +1112,8 @@ async function handleAdminRateLimitStats(request, env) {
   for (const category of Object.keys(clientsByCategory)) {
     stats.byCategory[category].uniqueClients = clientsByCategory[category].size
   }
+
+  if (truncated) stats.truncated = true
 
   return jsonResponse(stats)
 }

--- a/proxy/test/integration.test.js
+++ b/proxy/test/integration.test.js
@@ -127,9 +127,10 @@ describe('Integration - EEN API Communication', () => {
         }
       })
 
-      // Proxy deletes invalid sessions to force re-authentication
+      // Session is NOT deleted on refresh failure — TTL handles expiration.
+      // This avoids a race condition with KV eventual consistency.
       const session = await env.EEN_OAUTH_SESSIONS.get(sessionId)
-      expect(session).toBeNull()
+      expect(session).not.toBeNull()
     })
   })
 
@@ -380,10 +381,13 @@ describe('Integration - Admin Operations', () => {
 
     expect(response.status).toBe(200)
 
-    // Check only admin session remains
+    // Check only admin session remains (filter out RATE_LIMIT: and DEPLOY_ keys)
     const keys = await env.EEN_OAUTH_SESSIONS.list()
-    expect(keys.keys.length).toBe(1)
-    expect(keys.keys[0].name).toBe(adminSessionId)
+    const sessionKeys = keys.keys.filter(
+      k => !k.name.startsWith('RATE_LIMIT:') && !k.name.startsWith('DEPLOY_')
+    )
+    expect(sessionKeys.length).toBe(1)
+    expect(sessionKeys[0].name).toBe(adminSessionId)
   })
 
   it('should revoke all sessions including current', async () => {
@@ -407,8 +411,11 @@ describe('Integration - Admin Operations', () => {
 
     expect(response.status).toBe(200)
 
-    // All sessions should be deleted
+    // All sessions should be deleted (filter out RATE_LIMIT: and DEPLOY_ keys)
     const keys = await env.EEN_OAUTH_SESSIONS.list()
-    expect(keys.keys.length).toBe(0)
+    const sessionKeys = keys.keys.filter(
+      k => !k.name.startsWith('RATE_LIMIT:') && !k.name.startsWith('DEPLOY_')
+    )
+    expect(sessionKeys.length).toBe(0)
   })
 })

--- a/proxy/test/rate-limiting-low-limits.test.js
+++ b/proxy/test/rate-limiting-low-limits.test.js
@@ -176,18 +176,12 @@ describe('Rate Limiting - Low Limit Scenarios', () => {
       })
       expect(r1.status).toBe(200)
 
-      // Wait for counter increment
-      await new Promise(resolve => setTimeout(resolve, 100))
-
       // Second request should succeed
       const r2 = await fetchWithMetrics('http://localhost/health', {
         method: 'GET',
         headers
       })
       expect(r2.status).toBe(200)
-
-      // Wait for counter increment
-      await new Promise(resolve => setTimeout(resolve, 100))
 
       // Now manually set to limit
       await env.EEN_OAUTH_SESSIONS.put(key, '60', { expirationTtl: 120 })

--- a/proxy/test/rate-limiting.test.js
+++ b/proxy/test/rate-limiting.test.js
@@ -111,9 +111,6 @@ describe('Rate Limiting', () => {
 
       expect(response.status).toBe(200)
 
-      // Give a moment for the async counter increment
-      await new Promise(resolve => setTimeout(resolve, 100))
-
       // Check that a rate limit key was created
       const listResult = await env.EEN_OAUTH_SESSIONS.list({ prefix: 'RATE_LIMIT:health:' })
       expect(listResult.keys.length).toBeGreaterThan(0)
@@ -157,7 +154,6 @@ describe('Rate Limiting', () => {
       }
 
       // Verify counter is tracking
-      await new Promise(resolve => setTimeout(resolve, 100))
       const listResult = await env.EEN_OAUTH_SESSIONS.list({ prefix: 'RATE_LIMIT:health:' })
       expect(listResult.keys.length).toBeGreaterThan(0)
     })
@@ -177,9 +173,6 @@ describe('Rate Limiting', () => {
         headers: { 'CF-Connecting-IP': clientIp }
       })
       expect(response1.status).toBe(200)
-
-      // Wait for counter to update
-      await new Promise(resolve => setTimeout(resolve, 100))
 
       // Now set counter to exactly the limit
       await env.EEN_OAUTH_SESSIONS.put(key, '60', { expirationTtl: 120 })
@@ -252,9 +245,6 @@ describe('Rate Limiting', () => {
 
       expect(response.status).toBe(200)
 
-      // Wait for counter update
-      await new Promise(resolve => setTimeout(resolve, 100))
-
       // Check that the key includes the IP
       const listResult = await env.EEN_OAUTH_SESSIONS.list({ prefix: 'RATE_LIMIT:health:ip|' })
       const matchingKeys = listResult.keys.filter(k => k.name.includes(clientIp))
@@ -270,8 +260,6 @@ describe('Rate Limiting', () => {
       })
 
       expect(response.status).toBe(200)
-
-      await new Promise(resolve => setTimeout(resolve, 100))
 
       const listResult = await env.EEN_OAUTH_SESSIONS.list({ prefix: 'RATE_LIMIT:health:ip|' })
       const matchingKeys = listResult.keys.filter(k => k.name.includes(clientIp))
@@ -334,8 +322,6 @@ describe('Rate Limiting', () => {
         method: 'GET'
       })
 
-      await new Promise(resolve => setTimeout(resolve, 100))
-
       // Check that entries exist
       const listResult = await env.EEN_OAUTH_SESSIONS.list({ prefix: 'RATE_LIMIT:health:' })
       expect(listResult.keys.length).toBeGreaterThan(0)
@@ -397,9 +383,6 @@ describe('Rate Limiting', () => {
         }
       })
       expect(response.status).toBe(204)
-
-      // Wait for counter increment
-      await new Promise(resolve => setTimeout(resolve, 100))
 
       // Check that the counter was incremented
       const listResult = await env.EEN_OAUTH_SESSIONS.list({ prefix: 'RATE_LIMIT:health:ip|10.0.0.201' })


### PR DESCRIPTION
## Summary
- **Finding 2**: Remove session deletion on refresh failure to avoid KV eventual consistency race condition — sessions expire via TTL instead
- **Finding 3**: Add `listAllKVKeys()` pagination helper and update 4 admin endpoints to handle >1000 keys in KV
- **Finding 6**: Move rate limit counter increment into `checkRateLimit()` synchronously to prevent concurrent burst bypass; remove deferred `incrementRateLimitCounter` and `ctx.waitUntil` calls

## Files Changed
- `proxy/src/index.js` — all three proxy fixes
- `proxy/test/integration.test.js` — update assertions for new refresh failure behavior and filter rate limit keys
- `proxy/test/rate-limiting.test.js` — remove 7 unnecessary setTimeout waits
- `proxy/test/rate-limiting-low-limits.test.js` — remove 2 unnecessary setTimeout waits

## Test Results
- **Proxy unit tests**: 361 passed (12 test files)
- **Admin E2E**: 18 passed
- **Demo1 E2E**: 11 passed

## Versions
- Proxy: v1.3.10
- Admin: v1.1.3
- Demo1: v0.1.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)