### PR TITLE
Add Cache-Control: no-store to OAuth token responses

### DIFF
--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.3.15",
+      "version": "1.3.16",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -587,6 +587,10 @@ async function handleGetAccessToken(url, request, env) {
 
   const response = jsonResponse(responseData)
 
+  // RFC 6749 Section 5.1: token responses must not be cached
+  response.headers.set('Cache-Control', 'no-store')
+  response.headers.set('Pragma', 'no-cache')
+
   // Set session cookie
   response.headers.append(
     'Set-Cookie',
@@ -650,10 +654,16 @@ async function handleRefreshAccessToken(request, env) {
     expirationTtl: ttl
   })
 
-  return jsonResponse({
+  const response = jsonResponse({
     accessToken: tokens.access_token,
     expiresIn: tokens.expires_in
   })
+
+  // RFC 6749 Section 5.1: token responses must not be cached
+  response.headers.set('Cache-Control', 'no-store')
+  response.headers.set('Pragma', 'no-cache')
+
+  return response
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `Cache-Control: no-store` and `Pragma: no-cache` headers to `/proxy/getAccessToken` and `/proxy/refreshAccessToken` responses per RFC 6749 Section 5.1
- Prevents intermediary proxies or browser caches from retaining access tokens and session credentials

## Test plan
- [x] All 361 proxy tests pass (12 test files)
- [ ] Verify headers present in token responses via curl or browser devtools

🤖 Generated with [Claude Code](https://claude.com/claude-code)