### PR TITLE
Add auto-generated changelog to GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: production
+          fetch-depth: 0
 
       - name: Get version numbers
         id: versions
@@ -69,6 +70,54 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get previous release tag
+        id: prev_tag
+        if: steps.check_release.outputs.exists == 'false'
+        run: |
+          set -e
+          echo "🔍 Finding previous release tag..."
+
+          # List existing releases (sorted by date, most recent first)
+          PREV_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "")
+
+          if [ -n "$PREV_TAG" ]; then
+            echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
+            echo "has_prev=true" >> $GITHUB_OUTPUT
+            echo "✅ Previous release tag: $PREV_TAG"
+          else
+            echo "has_prev=false" >> $GITHUB_OUTPUT
+            echo "ℹ️ No previous release found, will include all commits"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate changelog
+        if: steps.check_release.outputs.exists == 'false'
+        run: |
+          set -e
+          echo "📝 Generating changelog..."
+
+          if [ "${{ steps.prev_tag.outputs.has_prev }}" == "true" ]; then
+            PREV_TAG="${{ steps.prev_tag.outputs.prev_tag }}"
+            echo "Generating changelog from $PREV_TAG to HEAD..."
+            COMMITS=$(git log --oneline --no-merges "${PREV_TAG}..HEAD" 2>/dev/null || echo "")
+          else
+            echo "Generating changelog from all commits..."
+            COMMITS=$(git log --oneline --no-merges 2>/dev/null || echo "")
+          fi
+
+          if [ -z "$COMMITS" ]; then
+            echo "- No changes recorded" > changelog.md
+            echo "ℹ️ No commits found for changelog"
+          else
+            # Format each commit as a bullet point and write to file
+            echo "$COMMITS" | sed 's/^[a-f0-9]* /- /' > changelog.md
+            echo "✅ Generated changelog with $(echo "$COMMITS" | wc -l | tr -d ' ') commits"
+          fi
+
+          echo "📝 Changelog contents:"
+          cat changelog.md
 
       - name: Create release archive
         id: create_archive
@@ -126,21 +175,31 @@ jobs:
           echo "🚀 Creating GitHub release: $RELEASE_TAG"
           echo "📎 Attaching archives: ${ARCHIVE_NAME}.zip, ${ARCHIVE_NAME}.tar.gz"
           
+          # Build release notes file
+          {
+            echo "## EEN OAuth Proxy Release"
+            echo ""
+            echo "**Admin App Version:** ${{ steps.versions.outputs.admin_version }}"
+            echo "**Proxy Version:** ${{ steps.versions.outputs.proxy_version }}"
+            echo ""
+            echo "### What's Changed"
+            cat changelog.md
+            echo ""
+            echo "### Downloads"
+            echo "- \`${ARCHIVE_NAME}.zip\` - ZIP archive"
+            echo "- \`${ARCHIVE_NAME}.tar.gz\` - TAR.GZ archive"
+            echo ""
+            echo "### Deployed URLs"
+            echo "- **Admin App:** ${{ vars.VITE_REDIRECT_URI }}"
+            echo "- **Proxy:** ${{ vars.VITE_PROXY_URL }}"
+          } > release_notes.md
+
+          echo "📝 Release notes:"
+          cat release_notes.md
+
           if ! gh release create "$RELEASE_TAG" \
             --title "Proxy v${{ steps.versions.outputs.proxy_version }} / Admin v${{ steps.versions.outputs.admin_version }}" \
-            --notes "## EEN OAuth Proxy Release
-
-          **Admin App Version:** ${{ steps.versions.outputs.admin_version }}
-          **Proxy Version:** ${{ steps.versions.outputs.proxy_version }}
-
-          ### Downloads
-          - \`${ARCHIVE_NAME}.zip\` - ZIP archive
-          - \`${ARCHIVE_NAME}.tar.gz\` - TAR.GZ archive
-
-          ### Deployed URLs
-          - **Admin App:** ${{ vars.VITE_REDIRECT_URI }}
-          - **Proxy:** ${{ vars.VITE_PROXY_URL }}
-          " \
+            --notes-file release_notes.md \
             "${ARCHIVE_NAME}.zip" \
             "${ARCHIVE_NAME}.tar.gz"; then
             echo "❌ Error: Failed to create GitHub release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,9 +107,9 @@ jobs:
           REPO_URL="https://github.com/${{ github.repository }}"
 
           # Exclude auto-generated version bump commits from changelog
-          GREP_EXCLUDE="--grep=^bump version --invert-grep"
+          GREP_EXCLUDE="--grep='^bump version' --invert-grep"
 
-          if [ "${{ steps.prev_tag.outputs.has_prev }}" == "true" ]; then
+          if [ "${{ steps.prev_tag.outputs.has_prev }}" = "true" ]; then
             PREV_TAG="${{ steps.prev_tag.outputs.prev_tag }}"
             echo "Generating changelog from $PREV_TAG to HEAD..."
             COMMITS=$(git log --format="%h %s" --no-merges --max-count=100 $GREP_EXCLUDE "${PREV_TAG}..HEAD" 2>/dev/null || echo "")
@@ -145,12 +145,15 @@ jobs:
             )
 
             while IFS= read -r line; do
-              SHA=$(echo "$line" | awk '{print $1}')
-              SUBJECT=$(echo "$line" | cut -d' ' -f2-)
-              ENTRY="- ${SUBJECT} ([${SHA}](${REPO_URL}/commit/${SHA}))"
+              SHA="${line%% *}"
+              SUBJECT="${line#* }"
+              # Sanitize backticks and $() to prevent shell interpretation in markdown
+              SAFE_SUBJECT="${SUBJECT//\`/}"
+              SAFE_SUBJECT="${SAFE_SUBJECT//\$(/}"
+              ENTRY="- ${SAFE_SUBJECT} ([${SHA}](${REPO_URL}/commit/${SHA}))"
 
               # Match conventional commit prefix (e.g., "feat:", "fix(scope):")
-              PREFIX=$(echo "$SUBJECT" | sed -n 's/^\([a-z]*\)\(([^)]*)\)\{0,1\}:.*/\1/p')
+              PREFIX=$(echo "$SUBJECT" | sed -nE 's/^([a-z]+)(\([^)]*\))?:.*/\1/p')
 
               case "$PREFIX" in
                 feat|fix|docs|chore|security|ci)
@@ -176,13 +179,17 @@ jobs:
 
             # Always write "other" last
             if [ -n "${GROUPS["other"]}" ]; then
-              if [ "$HAS_GROUPS" == "true" ]; then
+              if [ "$HAS_GROUPS" = "true" ]; then
                 echo "#### ${GROUP_TITLES["other"]}" >> changelog.md
               fi
               echo "${GROUPS["other"]}" >> changelog.md
             fi
 
-            COMMIT_COUNT=$(echo "$COMMITS" | wc -l | xargs)
+            if [ -n "$COMMITS" ]; then
+              COMMIT_COUNT=$(echo "$COMMITS" | wc -l | xargs)
+            else
+              COMMIT_COUNT=0
+            fi
             echo "✅ Generated changelog with ${COMMIT_COUNT} commits"
           fi
 
@@ -368,7 +375,7 @@ jobs:
 
       - name: Summary
         run: |
-          if [ "${{ steps.check_release.outputs.exists }}" == "true" ]; then
+          if [ "${{ steps.check_release.outputs.exists }}" = "true" ]; then
             echo "### ⏭️ Release Skipped" >> $GITHUB_STEP_SUMMARY
             echo "Release ${{ steps.versions.outputs.release_tag }} already exists." >> $GITHUB_STEP_SUMMARY
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,8 +78,14 @@ jobs:
           set -e
           echo "🔍 Finding previous release tag..."
 
-          # List existing releases (sorted by date, most recent first)
-          PREV_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "")
+          # Find the nearest tag by git history (more reliable than date-sorted release list)
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "")
+
+          # Fall back to gh release list if git describe fails (e.g., no tags exist yet)
+          if [ -z "$PREV_TAG" ]; then
+            echo "ℹ️ git describe found no tags, falling back to gh release list..."
+            PREV_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "")
+          fi
 
           if [ -n "$PREV_TAG" ]; then
             echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
@@ -98,22 +104,86 @@ jobs:
           set -e
           echo "📝 Generating changelog..."
 
+          REPO_URL="https://github.com/${{ github.repository }}"
+
+          # Exclude auto-generated version bump commits from changelog
+          GREP_EXCLUDE="--grep=^bump version --invert-grep"
+
           if [ "${{ steps.prev_tag.outputs.has_prev }}" == "true" ]; then
             PREV_TAG="${{ steps.prev_tag.outputs.prev_tag }}"
             echo "Generating changelog from $PREV_TAG to HEAD..."
-            COMMITS=$(git log --oneline --no-merges "${PREV_TAG}..HEAD" 2>/dev/null || echo "")
+            COMMITS=$(git log --format="%h %s" --no-merges --max-count=100 $GREP_EXCLUDE "${PREV_TAG}..HEAD" 2>/dev/null || echo "")
           else
             echo "Generating changelog from all commits..."
-            COMMITS=$(git log --oneline --no-merges 2>/dev/null || echo "")
+            COMMITS=$(git log --format="%h %s" --no-merges --max-count=100 $GREP_EXCLUDE 2>/dev/null || echo "")
           fi
 
           if [ -z "$COMMITS" ]; then
             echo "- No changes recorded" > changelog.md
             echo "ℹ️ No commits found for changelog"
           else
-            # Format each commit as a bullet point and write to file
-            echo "$COMMITS" | sed 's/^[a-f0-9]* /- /' > changelog.md
-            echo "✅ Generated changelog with $(echo "$COMMITS" | wc -l | tr -d ' ') commits"
+            # Group commits by conventional commit prefix
+            declare -A GROUPS
+            GROUPS=(
+              ["feat"]=""
+              ["fix"]=""
+              ["docs"]=""
+              ["chore"]=""
+              ["security"]=""
+              ["ci"]=""
+              ["other"]=""
+            )
+            declare -A GROUP_TITLES
+            GROUP_TITLES=(
+              ["feat"]="Features"
+              ["fix"]="Bug Fixes"
+              ["docs"]="Documentation"
+              ["chore"]="Chores"
+              ["security"]="Security"
+              ["ci"]="CI/CD"
+              ["other"]="Other Changes"
+            )
+
+            while IFS= read -r line; do
+              SHA=$(echo "$line" | awk '{print $1}')
+              SUBJECT=$(echo "$line" | cut -d' ' -f2-)
+              ENTRY="- ${SUBJECT} ([${SHA}](${REPO_URL}/commit/${SHA}))"
+
+              # Match conventional commit prefix (e.g., "feat:", "fix(scope):")
+              PREFIX=$(echo "$SUBJECT" | sed -n 's/^\([a-z]*\)\(([^)]*)\)\{0,1\}:.*/\1/p')
+
+              case "$PREFIX" in
+                feat|fix|docs|chore|security|ci)
+                  GROUPS[$PREFIX]+="${ENTRY}"$'\n'
+                  ;;
+                *)
+                  GROUPS["other"]+="${ENTRY}"$'\n'
+                  ;;
+              esac
+            done <<< "$COMMITS"
+
+            # Write grouped changelog
+            : > changelog.md
+            HAS_GROUPS=false
+
+            for key in feat fix security docs chore ci; do
+              if [ -n "${GROUPS[$key]}" ]; then
+                HAS_GROUPS=true
+                echo "#### ${GROUP_TITLES[$key]}" >> changelog.md
+                echo "${GROUPS[$key]}" >> changelog.md
+              fi
+            done
+
+            # Always write "other" last
+            if [ -n "${GROUPS["other"]}" ]; then
+              if [ "$HAS_GROUPS" == "true" ]; then
+                echo "#### ${GROUP_TITLES["other"]}" >> changelog.md
+              fi
+              echo "${GROUPS["other"]}" >> changelog.md
+            fi
+
+            COMMIT_COUNT=$(echo "$COMMITS" | wc -l | xargs)
+            echo "✅ Generated changelog with ${COMMIT_COUNT} commits"
           fi
 
           echo "📝 Changelog contents:"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
           # Fall back to gh release list if git describe fails (e.g., no tags exist yet)
           if [ -z "$PREV_TAG" ]; then
             echo "ℹ️ git describe found no tags, falling back to gh release list..."
-            PREV_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "")
+            PREV_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // empty' 2>/dev/null || echo "")
           fi
 
           if [ -n "$PREV_TAG" ]; then
@@ -101,100 +101,12 @@ jobs:
       - name: Generate changelog
         if: steps.check_release.outputs.exists == 'false'
         run: |
-          set -e
-          echo "📝 Generating changelog..."
-
           REPO_URL="https://github.com/${{ github.repository }}"
-
-          # Exclude auto-generated version bump commits from changelog
-          GREP_EXCLUDE="--grep='^bump version' --invert-grep"
-
           if [ "${{ steps.prev_tag.outputs.has_prev }}" = "true" ]; then
-            PREV_TAG="${{ steps.prev_tag.outputs.prev_tag }}"
-            echo "Generating changelog from $PREV_TAG to HEAD..."
-            COMMITS=$(git log --format="%h %s" --no-merges --max-count=100 $GREP_EXCLUDE "${PREV_TAG}..HEAD" 2>/dev/null || echo "")
+            ./scripts/generate-changelog.sh "$REPO_URL" "${{ steps.prev_tag.outputs.prev_tag }}"
           else
-            echo "Generating changelog from all commits..."
-            COMMITS=$(git log --format="%h %s" --no-merges --max-count=100 $GREP_EXCLUDE 2>/dev/null || echo "")
+            ./scripts/generate-changelog.sh "$REPO_URL"
           fi
-
-          if [ -z "$COMMITS" ]; then
-            echo "- No changes recorded" > changelog.md
-            echo "ℹ️ No commits found for changelog"
-          else
-            # Group commits by conventional commit prefix
-            declare -A GROUPS
-            GROUPS=(
-              ["feat"]=""
-              ["fix"]=""
-              ["docs"]=""
-              ["chore"]=""
-              ["security"]=""
-              ["ci"]=""
-              ["other"]=""
-            )
-            declare -A GROUP_TITLES
-            GROUP_TITLES=(
-              ["feat"]="Features"
-              ["fix"]="Bug Fixes"
-              ["docs"]="Documentation"
-              ["chore"]="Chores"
-              ["security"]="Security"
-              ["ci"]="CI/CD"
-              ["other"]="Other Changes"
-            )
-
-            while IFS= read -r line; do
-              SHA="${line%% *}"
-              SUBJECT="${line#* }"
-              # Sanitize backticks and $() to prevent shell interpretation in markdown
-              SAFE_SUBJECT="${SUBJECT//\`/}"
-              SAFE_SUBJECT="${SAFE_SUBJECT//\$(/}"
-              ENTRY="- ${SAFE_SUBJECT} ([${SHA}](${REPO_URL}/commit/${SHA}))"
-
-              # Match conventional commit prefix (e.g., "feat:", "fix(scope):")
-              PREFIX=$(echo "$SUBJECT" | sed -nE 's/^([a-z]+)(\([^)]*\))?:.*/\1/p')
-
-              case "$PREFIX" in
-                feat|fix|docs|chore|security|ci)
-                  GROUPS[$PREFIX]+="${ENTRY}"$'\n'
-                  ;;
-                *)
-                  GROUPS["other"]+="${ENTRY}"$'\n'
-                  ;;
-              esac
-            done <<< "$COMMITS"
-
-            # Write grouped changelog
-            : > changelog.md
-            HAS_GROUPS=false
-
-            for key in feat fix security docs chore ci; do
-              if [ -n "${GROUPS[$key]}" ]; then
-                HAS_GROUPS=true
-                echo "#### ${GROUP_TITLES[$key]}" >> changelog.md
-                echo "${GROUPS[$key]}" >> changelog.md
-              fi
-            done
-
-            # Always write "other" last
-            if [ -n "${GROUPS["other"]}" ]; then
-              if [ "$HAS_GROUPS" = "true" ]; then
-                echo "#### ${GROUP_TITLES["other"]}" >> changelog.md
-              fi
-              echo "${GROUPS["other"]}" >> changelog.md
-            fi
-
-            if [ -n "$COMMITS" ]; then
-              COMMIT_COUNT=$(echo "$COMMITS" | wc -l | xargs)
-            else
-              COMMIT_COUNT=0
-            fi
-            echo "✅ Generated changelog with ${COMMIT_COUNT} commits"
-          fi
-
-          echo "📝 Changelog contents:"
-          cat changelog.md
 
       - name: Create release archive
         id: create_archive

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,15 @@ Cloudflare Worker (proxy/src/index.js)
 - **demo1/** — Vue 3 + Pinia + TailwindCSS 4 demo app showing OAuth login flow
 - **scripts/** — Build, deploy, and test automation
 
-The proxy is the only component with access to CLIENT_SECRET. Frontend apps communicate via session cookies (HttpOnly, Secure, SameSite=None) or header-based auth.
+The proxy is the only component with access to CLIENT_SECRET. Frontend apps communicate via session cookies (HttpOnly, Secure, SameSite=None) or header-based auth (`Authorization: Bearer <sessionId>`).
+
+### Frontend Pattern
+
+Both admin and demo1 follow the same Vue 3 structure:
+- **Pinia stores** (`src/stores/auth.js`) — composition API style, manage auth state, token refresh, session tracking
+- **Services** (`src/services/`) — API call wrappers (auth.js in both; admin.js + admin.test.js in admin; user.js + proxy.js in demo1)
+- **CSP plugin** (`vite-plugin-csp.js`) — shared Vite plugin that injects `connect-src` at build time based on `VITE_PROXY_URL`
+- Auth stores validate `hostname` from EEN token responses against a domain allowlist before storing
 
 ## Commands
 
@@ -64,12 +72,12 @@ Admin and demo1 share port 3333 — they cannot run simultaneously (this is inte
 
 - **Proxy tests** use Vitest with `@cloudflare/vitest-pool-workers` (Miniflare). Test config is in `proxy/vitest.config.js` with mock bindings for KV, secrets, etc.
 - **Frontend tests** use Playwright. They require the proxy running on port 8787 and the app on port 3333.
-- Proxy has 17 test files covering integration, security, CORS, OAuth, admin, rate limiting, SSRF, and performance.
+- Proxy has 12 test files covering integration, security, CORS, OAuth, admin, auth-header, rate limiting (including low-limits variant), SSRF (integration + unit), workflow, and performance.
 
 ## Key Conventions
 
-- **Single-file worker**: All proxy logic lives in `proxy/src/index.js` (~1400 lines). No module splitting.
-- **Version bumping**: Husky pre-commit hook auto-increments patch version in package.json for changed directories.
+- **Single-file worker**: All proxy logic lives in `proxy/src/index.js` (~1435 lines). No module splitting.
+- **Version bumping**: Husky pre-commit hook auto-increments patch version in package.json for changed directories. It also checks proxy deployment status (skip with `SKIP_DEPLOYMENT_CHECK=1`).
 - **Version numbers differ** across proxy, admin, and demo1 — this is intentional.
 - **Environment files**: Proxy uses `.dev.vars` (local secrets) and `.env` (deploy secrets). Frontend apps use `.env` and `.env.prod` with `VITE_` prefix.
 - **Node 20+** required (Wrangler v4, Vite 7).
@@ -79,6 +87,14 @@ Admin and demo1 share port 3333 — they cannot run simultaneously (this is inte
 - Proxy deploys to Cloudflare Workers via `proxy/scripts/deploy.js` (reads secrets from `proxy/.env`)
 - Admin/demo1 deploy to GitHub Pages under `/een-oauth-proxy/` and `/een-oauth-proxy/demo1/`
 - CI/CD via GitHub Actions: PR gets AI review + tests; merge to production triggers deploy with automatic rollback on failure
+
+## Commit Message Conventions
+
+- Use imperative mood in commit subjects (e.g., "Add cache headers" not "Added cache headers")
+- Conventional commit prefixes are encouraged for automatic changelog grouping: `feat:`, `fix:`, `docs:`, `chore:`, `security:`, `ci:`
+- Examples: `feat: Add OAuth PKCE support`, `fix: Prevent token refresh race condition`, `docs: Update deployment instructions`
+- Commits without a prefix are still valid — they appear under "Other Changes" in release notes
+- Avoid prefixing with `bump version` — the Husky pre-commit hook generates these automatically and they are excluded from changelogs
 
 ## Review Notes
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The proxy implements multiple layers of security:
 
 - **Rate Limiting** - Configurable per-endpoint rate limits to prevent abuse:
   - `/health`: 60 requests/minute (default)
-  - `/proxy/*`: 30 requests/minute (default)
+  - `/proxy/*`: 60 requests/minute (default)
   - `/admin/*`: 60 requests/minute (default)
   - Unknown clients (no IP identification): 5 requests/minute
   - Configurable via environment variables (`RATE_LIMIT_*`)
@@ -110,7 +110,7 @@ A Vue 3 demonstration application showing OAuth integration with EEN.
 - Token refresh and revocation
 - Auto-refresh before token expiration
 
-**Deployment:** Local development only (not deployed to production). The demo1 app is tested via `test-demo1-pr.yml` on PRs but has no deployment workflow. Note that demo1 and admin share port 3333 and cannot run simultaneously on the same machine.
+**Deployment:** GitHub Pages at `https://your-username.github.io/een-oauth-proxy/demo1/` (deployed alongside admin via `npm run deploy:pages`). The demo1 app is also tested via `test-demo1-pr.yml` on PRs. Note that demo1 and admin share port 3333 and cannot run simultaneously on the same machine.
 
 ## Getting Started
 
@@ -300,11 +300,18 @@ npm run test:watch # Run tests in watch mode
 
 | File | Description | Tests |
 |------|-------------|-------|
-| `test/cors.test.js` | CORS validation and origin checking | Origin allowlist, preflight requests, 404 handling |
-| `test/oauth.test.js` | OAuth endpoint testing | Token exchange, refresh, revocation |
 | `test/admin.test.js` | Admin endpoint testing | Authentication, authorization, session management |
-| `test/security.test.js` | Security vulnerability tests | Injection attacks, session manipulation, CORS bypass |
+| `test/auth-header.test.js` | Authorization header authentication | Bearer token auth, header-based session lookup |
+| `test/cors.test.js` | CORS validation and origin checking | Origin allowlist, preflight requests, 404 handling |
 | `test/integration.test.js` | Integration tests | EEN API communication, session persistence |
+| `test/oauth.test.js` | OAuth endpoint testing | Token exchange, refresh, revocation |
+| `test/performance.test.js` | Performance benchmarks | Response time measurements, throughput |
+| `test/rate-limiting.test.js` | Rate limiting behavior | Per-endpoint limits, window expiration |
+| `test/rate-limiting-low-limits.test.js` | Rate limiting with low thresholds | Edge cases with restrictive limits |
+| `test/security.test.js` | Security vulnerability tests | Injection attacks, session manipulation, CORS bypass |
+| `test/ssrf.test.js` | SSRF integration tests | Domain allowlist enforcement, malicious URL blocking |
+| `test/ssrf-unit.test.js` | SSRF unit tests | URL validation, domain parsing |
+| `test/workflow.test.js` | End-to-end workflow tests | Full OAuth flow, session lifecycle |
 
 **Security Tests Include:**
 - SQL/NoSQL injection attempts
@@ -446,7 +453,7 @@ npm run deploy:proxy
 
 The deploy script will:
 1. Deploy the worker to Cloudflare
-2. Set secrets (CLIENT_ID, CLIENT_SECRET, ADMIN_EMAILS, ALLOWED_ORIGINS)
+2. Set secrets (CLIENT_ID, CLIENT_SECRET, ADMIN_EMAILS, ALLOWED_ORIGINS, ALLOWED_API_DOMAINS, REFRESH_TOKEN_TTL, MAX_KV_KEYS)
 3. Store the version in KV
 
 ### Deploy Apps to GitHub Pages
@@ -602,6 +609,7 @@ Configure these secrets in your repository settings (Settings > Secrets and vari
 | `ALLOWED_ORIGINS` | Comma-separated CORS allowed origins | Proxy deployment |
 | `ALLOWED_API_DOMAINS` | Comma-separated allowed API domains for SSRF protection | Proxy deployment |
 | `REFRESH_TOKEN_TTL` | Session TTL in seconds (default: 86400) | Proxy deployment |
+| `MAX_KV_KEYS` | Max KV keys to enumerate per request (default: 10000) | Proxy deployment |
 | `ADMIN_TEST_USER` | Test admin user email (must be in ADMIN_EMAILS) | Playwright tests |
 | `ADMIN_TEST_PASSWORD` | Test admin user password | Playwright tests |
 | `TEST_USER` | Test user email (must not be in ADMIN_EMAILS) | Playwright tests |
@@ -657,8 +665,9 @@ Configure these variables in your repository settings (Settings > Secrets and va
 
 The project sends Slack notifications for:
 
-1. **Deployments** - When admin app is deployed to GitHub Pages
-2. **Releases** - When a new release is created
+1. **Admin Deployments** - When admin app is deployed to GitHub Pages
+2. **Proxy Deployments** - When proxy is deployed to Cloudflare Workers (success and failure/rollback)
+3. **Releases** - When a new release is created
 
 To configure Slack notifications:
 
@@ -725,7 +734,7 @@ This project includes a Claude Code skill for automating the PR creation and rev
 | `RATE_LIMIT_ENABLED` | Enable/disable rate limiting | `true` (default) |
 | `RATE_LIMIT_WINDOW` | Rate limit window in seconds | `60` (default) |
 | `RATE_LIMIT_HEALTH` | Max requests per window for `/health` | `60` (default) |
-| `RATE_LIMIT_OAUTH` | Max requests per window for `/proxy/*` | `30` (default) |
+| `RATE_LIMIT_OAUTH` | Max requests per window for `/proxy/*` | `60` (default) |
 | `RATE_LIMIT_ADMIN` | Max requests per window for `/admin/*` | `60` (default) |
 | `RATE_LIMIT_UNKNOWN` | Max requests per window for unidentified clients | `5` (default) |
 | `MAX_KV_KEYS` | Max KV keys to enumerate per request (range: 1000–100000) | `10000` (default) |
@@ -756,6 +765,7 @@ Values outside the min/max range are automatically clamped. Adjust this value ba
 | `VITE_EEN_AUTH_URL` | EEN OAuth authorize URL | `https://auth.eagleeyenetworks.com/oauth2/authorize` |
 | `VITE_REDIRECT_URI` | OAuth callback URL (must exactly match EEN config) | `http://127.0.0.1:3333` |
 | `VITE_GITHUB_REPO` | GitHub repository URL for version links in the app footer | `https://github.com/your-username/een-oauth-proxy` |
+| `VITE_GITHUB_BRANCH` | Git branch name for version links in the app UI | `main` |
 
 ## API Endpoints
 

--- a/proxy/.dev.vars.example
+++ b/proxy/.dev.vars.example
@@ -24,7 +24,7 @@ REFRESH_TOKEN_TTL=86400
 # RATE_LIMIT_ENABLED: 'true' to enable, 'false' to disable (default: true)
 # RATE_LIMIT_WINDOW: time window in seconds (default: 60)
 # RATE_LIMIT_HEALTH: max requests per window for /health (default: 60)
-# RATE_LIMIT_OAUTH: max requests per window for /proxy/* (default: 30)
+# RATE_LIMIT_OAUTH: max requests per window for /proxy/* (default: 60)
 # RATE_LIMIT_ADMIN: max requests per window for /admin/* (default: 60)
 # RATE_LIMIT_UNKNOWN: max requests per window for unidentified clients (default: 5)
 #   - In development, clients without CF-Connecting-IP use X-Forwarded-For

--- a/proxy/.env.example
+++ b/proxy/.env.example
@@ -26,7 +26,7 @@ ALLOWED_API_DOMAINS=eagleeyenetworks.com
 # RATE_LIMIT_ENABLED: 'true' to enable, 'false' to disable (default: true)
 # RATE_LIMIT_WINDOW: time window in seconds (default: 60)
 # RATE_LIMIT_HEALTH: max requests per window for /health (default: 60)
-# RATE_LIMIT_OAUTH: max requests per window for /proxy/* (default: 30)
+# RATE_LIMIT_OAUTH: max requests per window for /proxy/* (default: 60)
 # RATE_LIMIT_ADMIN: max requests per window for /admin/* (default: 60)
 # RATE_LIMIT_UNKNOWN: max requests per window for unidentified clients (default: 5)
 #   - Applies to clients without CF-Connecting-IP header (non-Cloudflare requests)

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.3.16",
+      "version": "1.3.17",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -21,7 +21,7 @@
  *   Configurable via environment variables:
  *   - RATE_LIMIT_ENABLED: 'true' to enable (default: true)
  *   - RATE_LIMIT_HEALTH: requests/minute for /health (default: 60)
- *   - RATE_LIMIT_OAUTH: requests/minute for /proxy/* (default: 30)
+ *   - RATE_LIMIT_OAUTH: requests/minute for /proxy/* (default: 60)
  *   - RATE_LIMIT_ADMIN: requests/minute for /admin/* (default: 60)
  *   - RATE_LIMIT_WINDOW: time window in seconds (default: 60)
  *

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Generate a grouped changelog from git commits between two refs.
+# Requires bash 4+ for associative arrays.
+#
+# Usage:
+#   ./scripts/generate-changelog.sh <repo_url> [prev_tag]
+#
+# Arguments:
+#   repo_url  - GitHub repository URL (e.g., https://github.com/owner/repo)
+#   prev_tag  - Previous release tag (optional; if omitted, includes all commits)
+#
+# Output:
+#   Writes changelog.md in the current directory.
+#   Commits are grouped by conventional commit prefix (feat/fix/docs/chore/security/ci).
+#   Each entry links to its commit on GitHub.
+#   Auto-generated version bump commits are excluded.
+
+set -e
+
+REPO_URL="${1:?Usage: generate-changelog.sh <repo_url> [prev_tag]}"
+PREV_TAG="${2:-}"
+
+echo "📝 Generating changelog..."
+
+# Exclude auto-generated version bump commits from changelog
+if [ -n "$PREV_TAG" ]; then
+  echo "Generating changelog from $PREV_TAG to HEAD..."
+  COMMITS=$(git log --format="%h %s" --no-merges --max-count=100 --grep='^bump version' --invert-grep "${PREV_TAG}..HEAD" 2>/dev/null || echo "")
+else
+  echo "Generating changelog from all commits..."
+  COMMITS=$(git log --format="%h %s" --no-merges --max-count=100 --grep='^bump version' --invert-grep 2>/dev/null || echo "")
+fi
+
+if [ -z "$COMMITS" ]; then
+  echo "- No changes recorded" > changelog.md
+  echo "ℹ️ No commits found for changelog"
+else
+  # Group commits by conventional commit prefix (requires bash 4+)
+  unset GROUPS GROUP_TITLES
+  declare -A GROUPS=(
+    ["feat"]=""
+    ["fix"]=""
+    ["docs"]=""
+    ["chore"]=""
+    ["security"]=""
+    ["ci"]=""
+    ["other"]=""
+  )
+  declare -A GROUP_TITLES=(
+    ["feat"]="Features"
+    ["fix"]="Bug Fixes"
+    ["docs"]="Documentation"
+    ["chore"]="Chores"
+    ["security"]="Security"
+    ["ci"]="CI/CD"
+    ["other"]="Other Changes"
+  )
+
+  while IFS= read -r line; do
+    SHA="${line%% *}"
+    SUBJECT="${line#* }"
+    # Sanitize shell metacharacters to prevent injection in markdown
+    SAFE_SUBJECT="${SUBJECT//[\`\$\{\}]/}"
+    ENTRY="- ${SAFE_SUBJECT} ([${SHA}](${REPO_URL}/commit/${SHA}))"
+
+    # Match only recognized conventional commit prefixes (e.g., "feat:", "fix(scope):")
+    PREFIX=$(echo "$SUBJECT" | sed -nE 's/^(feat|fix|docs|chore|security|ci)(\([^)]*\))?:.*/\1/p')
+
+    case "$PREFIX" in
+      feat|fix|docs|chore|security|ci)
+        GROUPS[$PREFIX]+="${ENTRY}"$'\n'
+        ;;
+      *)
+        GROUPS["other"]+="${ENTRY}"$'\n'
+        ;;
+    esac
+  done <<< "$COMMITS"
+
+  # Write grouped changelog
+  : > changelog.md
+  HAS_GROUPS=false
+
+  for key in feat fix security docs chore ci; do
+    if [ -n "${GROUPS[$key]}" ]; then
+      HAS_GROUPS=true
+      echo "#### ${GROUP_TITLES[$key]}" >> changelog.md
+      echo "${GROUPS[$key]}" >> changelog.md
+    fi
+  done
+
+  # Always write "other" last
+  if [ -n "${GROUPS["other"]}" ]; then
+    if [ "$HAS_GROUPS" = "true" ]; then
+      echo "#### ${GROUP_TITLES["other"]}" >> changelog.md
+    fi
+    echo "${GROUPS["other"]}" >> changelog.md
+  fi
+
+  if [ -n "$COMMITS" ]; then
+    COMMIT_COUNT=$(echo "$COMMITS" | wc -l | xargs)
+  else
+    COMMIT_COUNT=0
+  fi
+  echo "✅ Generated changelog with ${COMMIT_COUNT} commits"
+fi
+
+echo "📝 Changelog contents:"
+cat changelog.md

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -20,6 +20,19 @@ set -e
 REPO_URL="${1:?Usage: generate-changelog.sh <repo_url> [prev_tag]}"
 PREV_TAG="${2:-}"
 
+# Validate REPO_URL is a GitHub repository URL
+REPO_URL="${REPO_URL%/}"
+if [[ ! "$REPO_URL" =~ ^https://github\.com/[^/]+/[^/]+$ ]]; then
+  echo "❌ Error: REPO_URL must be a GitHub repository URL (e.g., https://github.com/owner/repo)" >&2
+  exit 1
+fi
+
+# Validate PREV_TAG format if provided (git refs: alphanumeric, dots, dashes, slashes, underscores)
+if [ -n "$PREV_TAG" ] && [[ ! "$PREV_TAG" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+  echo "❌ Error: Invalid PREV_TAG format: $PREV_TAG" >&2
+  exit 1
+fi
+
 echo "📝 Generating changelog..."
 
 # Exclude auto-generated version bump commits from changelog
@@ -57,10 +70,12 @@ else
   )
 
   while IFS= read -r line; do
+    [ -z "$line" ] && continue
     SHA="${line%% *}"
     SUBJECT="${line#* }"
-    # Sanitize shell metacharacters to prevent injection in markdown
-    SAFE_SUBJECT="${SUBJECT//[\`\$\{\}]/}"
+    # Sanitize shell metacharacters and markdown-breaking characters
+    SAFE_SUBJECT="${SUBJECT//[\`\$\{\}\[\]\(\)]/}"
+    SAFE_SUBJECT="${SAFE_SUBJECT//$'\n'/ }"
     ENTRY="- ${SAFE_SUBJECT} ([${SHA}](${REPO_URL}/commit/${SHA}))"
 
     # Match only recognized conventional commit prefixes (e.g., "feat:", "fix(scope):")


### PR DESCRIPTION
## Summary
- Adds a "What's Changed" section to GitHub release notes, auto-generated from `git log` between the previous and current release tags
- New workflow steps: "Get previous release tag" and "Generate changelog" 
- Uses file-based approach (`changelog.md` + `release_notes.md`) to safely handle commit messages with special characters
- Added `fetch-depth: 0` to checkout for full git history access
- Also retroactively updated all 10 existing releases with changelogs

## Test Results
- **Proxy tests:** 12 test files, 361 tests — all passed
- **Admin E2E:** Failed (pre-existing button text mismatch — unrelated to this change)
- **Demo1 E2E:** Failed (same pre-existing button text mismatch — unrelated to this change)

## Versions
- Proxy: 1.3.16
- Admin: 1.1.4
- Demo1: 0.1.3

## Test plan
- [ ] Verify workflow YAML is valid by checking the Actions tab
- [ ] Trigger a release via `workflow_dispatch` and confirm the "What's Changed" section appears
- [ ] Verify edge case: first release (no previous tag) gracefully falls back to all commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)