### PR TITLE
Fix CI/CD expression injection in GitHub Actions workflows

### DIFF
--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -330,6 +330,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           PACKAGE_VERSION: ${{ steps.version.outputs.version }}
         run: |
+          set -o pipefail
           # Build JSON safely using jq to prevent injection via special characters
           WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           jq -n \

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -60,11 +60,11 @@ jobs:
 
       - name: Check if deployment needed
         id: check
+        env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+          DEPLOYED_VERSION: ${{ steps.deployed.outputs.deployed_version }}
+          FORCE_DEPLOY: ${{ inputs.force_deploy }}
         run: |
-          PACKAGE_VERSION="${{ steps.version.outputs.version }}"
-          DEPLOYED_VERSION="${{ steps.deployed.outputs.deployed_version }}"
-          FORCE_DEPLOY="${{ inputs.force_deploy }}"
-
           if [ "$FORCE_DEPLOY" = "true" ]; then
             echo "::warning::Force deploy requested - bypassing version check"
             echo "should_deploy=true" >> $GITHUB_OUTPUT
@@ -78,10 +78,13 @@ jobs:
 
       - name: Skip deployment (versions match)
         if: steps.check.outputs.should_deploy == 'false'
+        env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+          DEPLOYED_VERSION: ${{ steps.deployed.outputs.deployed_version }}
         run: |
           echo "## Deployment Skipped" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Package version (${{ steps.version.outputs.version }}) matches deployed version (${{ steps.deployed.outputs.deployed_version }})." >> $GITHUB_STEP_SUMMARY
+          echo "Package version ($PACKAGE_VERSION) matches deployed version ($DEPLOYED_VERSION)." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Use **force_deploy** input to deploy anyway (use with caution)." >> $GITHUB_STEP_SUMMARY
 
@@ -128,28 +131,35 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          SECRET_CLIENT_ID: ${{ secrets.VITE_EEN_CLIENT_ID }}
+          SECRET_CLIENT_SECRET: ${{ secrets.EEN_CLIENT_SECRET }}
+          SECRET_ADMIN_EMAILS: ${{ secrets.ADMIN_EMAILS }}
+          SECRET_ALLOWED_ORIGINS: ${{ secrets.ALLOWED_ORIGINS }}
+          SECRET_ALLOWED_API_DOMAINS: ${{ secrets.ALLOWED_API_DOMAINS }}
+          SECRET_REFRESH_TOKEN_TTL: ${{ secrets.REFRESH_TOKEN_TTL }}
+          SECRET_MAX_KV_KEYS: ${{ secrets.MAX_KV_KEYS }}
         run: |
           cd proxy
           echo "Setting CLIENT_ID..."
-          printf '%s' "${{ secrets.VITE_EEN_CLIENT_ID }}" | npx wrangler secret put CLIENT_ID
+          printf '%s' "$SECRET_CLIENT_ID" | npx wrangler secret put CLIENT_ID
 
           echo "Setting CLIENT_SECRET..."
-          printf '%s' "${{ secrets.EEN_CLIENT_SECRET }}" | npx wrangler secret put CLIENT_SECRET
+          printf '%s' "$SECRET_CLIENT_SECRET" | npx wrangler secret put CLIENT_SECRET
 
           echo "Setting ADMIN_EMAILS..."
-          printf '%s' "${{ secrets.ADMIN_EMAILS }}" | npx wrangler secret put ADMIN_EMAILS
+          printf '%s' "$SECRET_ADMIN_EMAILS" | npx wrangler secret put ADMIN_EMAILS
 
           echo "Setting ALLOWED_ORIGINS..."
-          printf '%s' "${{ secrets.ALLOWED_ORIGINS }}" | npx wrangler secret put ALLOWED_ORIGINS
+          printf '%s' "$SECRET_ALLOWED_ORIGINS" | npx wrangler secret put ALLOWED_ORIGINS
 
           echo "Setting ALLOWED_API_DOMAINS..."
-          printf '%s' "${{ secrets.ALLOWED_API_DOMAINS }}" | npx wrangler secret put ALLOWED_API_DOMAINS
+          printf '%s' "$SECRET_ALLOWED_API_DOMAINS" | npx wrangler secret put ALLOWED_API_DOMAINS
 
           echo "Setting REFRESH_TOKEN_TTL..."
-          printf '%s' "${{ secrets.REFRESH_TOKEN_TTL }}" | npx wrangler secret put REFRESH_TOKEN_TTL
+          printf '%s' "$SECRET_REFRESH_TOKEN_TTL" | npx wrangler secret put REFRESH_TOKEN_TTL
 
           echo "Setting MAX_KV_KEYS..."
-          printf '%s' "${{ secrets.MAX_KV_KEYS }}" | npx wrangler secret put MAX_KV_KEYS
+          printf '%s' "$SECRET_MAX_KV_KEYS" | npx wrangler secret put MAX_KV_KEYS
 
       - name: Store deploy version in KV
         if: steps.check.outputs.should_deploy == 'true'
@@ -157,10 +167,11 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
         run: |
           cd proxy
           DEPLOY_TIME=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
-          VERSION_STRING="een-oauth-proxy - ${{ steps.version.outputs.version }} - $DEPLOY_TIME"
+          VERSION_STRING="een-oauth-proxy - ${PACKAGE_VERSION} - $DEPLOY_TIME"
           # Get namespace ID from wrangler.toml (look for id within 10 lines after kv_namespaces section)
           NAMESPACE_ID=$(grep -A 10 '\[\[kv_namespaces\]\]' wrangler.toml | grep 'id = "' | head -1 | sed 's/.*id = "\([^"]*\)".*/\1/')
           # Validate namespace ID was found and has correct format (32-char hex)
@@ -179,11 +190,13 @@ jobs:
       - name: Wait for deployment propagation
         if: steps.check.outputs.should_deploy == 'true'
         id: wait_propagation
+        env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
         run: |
           # Poll health endpoint until version matches or timeout (exponential backoff)
           # Note: Health endpoint returns full version string like "een-oauth-proxy - 1.2.37 - timestamp"
           # so we check if the expected version number is contained in the response
-          EXPECTED_VERSION="${{ steps.version.outputs.version }}"
+          EXPECTED_VERSION="$PACKAGE_VERSION"
           MAX_ATTEMPTS=6
           WAIT_TIME=5
 
@@ -216,6 +229,14 @@ jobs:
       - name: Check rollback conditions
         if: always() && steps.check.outputs.should_deploy == 'true'
         id: rollback_check
+        env:
+          DEPLOY_SUCCEEDED: ${{ steps.deploy.outputs.deployed == 'true' }}
+          SECRETS_FAILED: ${{ steps.set_secrets.outcome == 'failure' }}
+          STORE_VERSION_FAILED: ${{ steps.store_version.outcome == 'failure' }}
+          PROPAGATION_FAILED: ${{ steps.wait_propagation.outcome == 'failure' }}
+          VERIFY_FAILED: ${{ steps.verify.outcome == 'failure' }}
+          DEPLOYMENT_COMPLETE: ${{ steps.store_version.outputs.deployment_complete == 'true' }}
+          HAS_PREVIOUS: ${{ steps.current_deployment.outputs.has_previous_version == 'true' }}
         run: |
           # Determine if rollback should be attempted
           # Rollback triggers if deploy succeeded but any post-deployment step failed:
@@ -224,13 +245,6 @@ jobs:
           # - propagation wait failed, OR
           # - verification failed, OR
           # - deployment_complete flag not set
-          DEPLOY_SUCCEEDED="${{ steps.deploy.outputs.deployed == 'true' }}"
-          SECRETS_FAILED="${{ steps.set_secrets.outcome == 'failure' }}"
-          STORE_VERSION_FAILED="${{ steps.store_version.outcome == 'failure' }}"
-          PROPAGATION_FAILED="${{ steps.wait_propagation.outcome == 'failure' }}"
-          VERIFY_FAILED="${{ steps.verify.outcome == 'failure' }}"
-          DEPLOYMENT_COMPLETE="${{ steps.store_version.outputs.deployment_complete == 'true' }}"
-          HAS_PREVIOUS="${{ steps.current_deployment.outputs.has_previous_version == 'true' }}"
 
           echo "Deploy succeeded: $DEPLOY_SUCCEEDED"
           echo "Secrets failed: $SECRETS_FAILED"
@@ -266,9 +280,9 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ROLLBACK_VERSION: ${{ steps.current_deployment.outputs.version_id }}
         run: |
           cd proxy
-          ROLLBACK_VERSION="${{ steps.current_deployment.outputs.version_id }}"
           echo "::error::Verification failed! Rolling back to version: $ROLLBACK_VERSION"
           npx wrangler versions deploy "$ROLLBACK_VERSION" --yes
           echo "rollback_performed=true" >> $GITHUB_OUTPUT
@@ -298,11 +312,14 @@ jobs:
 
       - name: Deployment summary
         if: steps.check.outputs.should_deploy == 'true' && success()
+        env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+          DEPLOYED_VERSION: ${{ steps.deployed.outputs.deployed_version }}
         run: |
           echo "## Proxy Deployment Complete" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Previous:** ${{ steps.deployed.outputs.deployed_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** $PACKAGE_VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "**Previous:** $DEPLOYED_VERSION" >> $GITHUB_STEP_SUMMARY
           echo "**Worker:** een-oauth-proxy" >> $GITHUB_STEP_SUMMARY
           echo "**URL:** $PROXY_URL" >> $GITHUB_STEP_SUMMARY
 
@@ -311,87 +328,55 @@ jobs:
         continue-on-error: true
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          # Use env var to prevent webhook URL exposure in error output
-          # Note: Admin App URL is /een-oauth-proxy (not /een-oauth-proxy/admin/) - GitHub Pages serves it from base path
-          curl -sf -X POST "$SLACK_WEBHOOK" \
-            -H "Content-Type: application/json" \
-            -d '{
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "Proxy Deployed to Cloudflare",
-                    "emoji": true
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Version:*\n${{ steps.version.outputs.version }}"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Status:*\n:white_check_mark: Success"
-                    }
-                  ]
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "Health Check"
-                      },
-                      "url": "'"$PROXY_URL"'/health"
-                    },
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "Admin App"
-                      },
-                      "url": "https://klaushofrichter.github.io/een-oauth-proxy"
-                    },
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "View Workflow"
-                      },
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
+          # Build JSON safely using jq to prevent injection via special characters
+          WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          jq -n \
+            --arg version "$PACKAGE_VERSION" \
+            --arg health_url "${PROXY_URL}/health" \
+            --arg workflow_url "$WORKFLOW_URL" \
+            '{
+              blocks: [
+                {type: "header", text: {type: "plain_text", text: "Proxy Deployed to Cloudflare", emoji: true}},
+                {type: "section", fields: [
+                  {type: "mrkdwn", text: ("*Version:*\n" + $version)},
+                  {type: "mrkdwn", text: "*Status:*\n:white_check_mark: Success"}
+                ]},
+                {type: "actions", elements: [
+                  {type: "button", text: {type: "plain_text", text: "Health Check"}, url: $health_url},
+                  {type: "button", text: {type: "plain_text", text: "Admin App"}, url: "https://klaushofrichter.github.io/een-oauth-proxy"},
+                  {type: "button", text: {type: "plain_text", text: "View Workflow"}, url: $workflow_url}
+                ]}
               ]
-            }'
+            }' | curl -sf -X POST "$SLACK_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d @-
 
       - name: Notify Slack on failure
         if: failure()
         continue-on-error: true
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+          ROLLBACK_PERFORMED: ${{ steps.rollback.outputs.rollback_performed }}
+          PREVIOUS_VERSION_ID: ${{ steps.current_deployment.outputs.version_id }}
+          HAS_PREVIOUS_VERSION: ${{ steps.current_deployment.outputs.has_previous_version }}
         run: |
           set -o pipefail
-          VERSION="${{ steps.version.outputs.version }}"
-          VERSION="${VERSION:-unknown}"
+          VERSION="${PACKAGE_VERSION:-unknown}"
           ROLLBACK_STATUS=""
-          if [ "${{ steps.rollback.outputs.rollback_performed }}" = "true" ]; then
-            ROLLBACK_STATUS=" (rolled back to ${{ steps.current_deployment.outputs.version_id }})"
-          elif [ "${{ steps.current_deployment.outputs.has_previous_version }}" != "true" ]; then
+          if [ "$ROLLBACK_PERFORMED" = "true" ]; then
+            ROLLBACK_STATUS=" (rolled back to ${PREVIOUS_VERSION_ID})"
+          elif [ "$HAS_PREVIOUS_VERSION" != "true" ]; then
             ROLLBACK_STATUS=" (rollback not possible - no previous version)"
           fi
           # Build JSON safely using jq to prevent injection via special characters
-          # Use env var to prevent webhook URL exposure in error output
+          WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           jq -n \
             --arg title "Proxy Deployment Failed${ROLLBACK_STATUS}" \
             --arg version "$VERSION" \
-            --arg url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --arg url "$WORKFLOW_URL" \
             '{
               blocks: [
                 {type: "header", text: {type: "plain_text", text: $title, emoji: true}},

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -331,7 +331,7 @@ jobs:
           PACKAGE_VERSION: ${{ steps.version.outputs.version }}
         run: |
           # Build JSON safely using jq to prevent injection via special characters
-          WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           jq -n \
             --arg version "$PACKAGE_VERSION" \
             --arg health_url "${PROXY_URL}/health" \
@@ -372,7 +372,7 @@ jobs:
             ROLLBACK_STATUS=" (rollback not possible - no previous version)"
           fi
           # Build JSON safely using jq to prevent injection via special characters
-          WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           jq -n \
             --arg title "Proxy Deployment Failed${ROLLBACK_STATUS}" \
             --arg version "$VERSION" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Generate changelog
         if: steps.check_release.outputs.exists == 'false'
         run: |
-          REPO_URL="https://github.com/${{ github.repository }}"
+          REPO_URL="https://github.com/${GITHUB_REPOSITORY}"
           if [ "$HAS_PREV" = "true" ]; then
             ./scripts/generate-changelog.sh "$REPO_URL" "$PREV_TAG"
           else
@@ -206,17 +206,18 @@ jobs:
           fi
 
           echo "✅ Successfully created release: $RELEASE_TAG"
-          echo "🔗 Release URL: https://github.com/${{ github.repository }}/releases/tag/$RELEASE_TAG"
+          echo "🔗 Release URL: https://github.com/${GITHUB_REPOSITORY}/releases/tag/$RELEASE_TAG"
 
       - name: Notify Slack
         if: steps.check_release.outputs.exists == 'false'
+        continue-on-error: true
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           RELEASE_TAG: ${{ steps.versions.outputs.release_tag }}
           PROXY_VERSION: ${{ steps.versions.outputs.proxy_version }}
           ADMIN_VERSION: ${{ steps.versions.outputs.admin_version }}
         run: |
-          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${RELEASE_TAG}"
+          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}"
           RELEASE_TIME=$(TZ='America/Chicago' date +"%Y-%m-%d %H:%M:%S CT")
 
           # Build JSON safely using jq to prevent injection via special characters
@@ -225,8 +226,8 @@ jobs:
             --arg admin_ver "$ADMIN_VERSION" \
             --arg proxy_ver "$PROXY_VERSION" \
             --arg release_time "$RELEASE_TIME" \
-            --arg repo "${{ github.server_url }}/${{ github.repository }}" \
-            --arg repo_name "${{ github.repository }}" \
+            --arg repo "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+            --arg repo_name "$GITHUB_REPOSITORY" \
             --arg admin_url "${{ vars.VITE_REDIRECT_URI }}" \
             --arg proxy_url "${{ vars.VITE_PROXY_URL }}" \
             --arg release_url "$RELEASE_URL" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,9 +58,8 @@ jobs:
         id: check_release
         run: |
           set -e
-          RELEASE_TAG="${{ steps.versions.outputs.release_tag }}"
           echo "🔍 Checking if release '$RELEASE_TAG' already exists..."
-          
+
           if gh release view "$RELEASE_TAG" > /dev/null 2>&1; then
             echo "exists=true" >> $GITHUB_OUTPUT
             echo "ℹ️ Release $RELEASE_TAG already exists, skipping creation"
@@ -70,6 +69,7 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.versions.outputs.release_tag }}
 
       - name: Get previous release tag
         id: prev_tag
@@ -102,18 +102,24 @@ jobs:
         if: steps.check_release.outputs.exists == 'false'
         run: |
           REPO_URL="https://github.com/${{ github.repository }}"
-          if [ "${{ steps.prev_tag.outputs.has_prev }}" = "true" ]; then
-            ./scripts/generate-changelog.sh "$REPO_URL" "${{ steps.prev_tag.outputs.prev_tag }}"
+          if [ "$HAS_PREV" = "true" ]; then
+            ./scripts/generate-changelog.sh "$REPO_URL" "$PREV_TAG"
           else
             ./scripts/generate-changelog.sh "$REPO_URL"
           fi
+        env:
+          HAS_PREV: ${{ steps.prev_tag.outputs.has_prev }}
+          PREV_TAG: ${{ steps.prev_tag.outputs.prev_tag }}
 
       - name: Create release archive
         id: create_archive
         if: steps.check_release.outputs.exists == 'false'
+        env:
+          PROXY_VERSION: ${{ steps.versions.outputs.proxy_version }}
+          ADMIN_VERSION: ${{ steps.versions.outputs.admin_version }}
         run: |
           set -e
-          ARCHIVE_NAME="een-oauth-proxy-v${{ steps.versions.outputs.proxy_version }}_v${{ steps.versions.outputs.admin_version }}"
+          ARCHIVE_NAME="een-oauth-proxy-v${PROXY_VERSION}_v${ADMIN_VERSION}"
           echo "📦 Creating release archives with name: $ARCHIVE_NAME"
           
           echo "Creating ZIP archive..."
@@ -146,30 +152,34 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.check_release.outputs.exists == 'false' && steps.create_archive.outputs.archive_name != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARCHIVE_NAME: ${{ steps.create_archive.outputs.archive_name }}
+          RELEASE_TAG: ${{ steps.versions.outputs.release_tag }}
+          ADMIN_VERSION: ${{ steps.versions.outputs.admin_version }}
+          PROXY_VERSION: ${{ steps.versions.outputs.proxy_version }}
         run: |
           set -e
-          ARCHIVE_NAME="${{ steps.create_archive.outputs.archive_name }}"
-          RELEASE_TAG="${{ steps.versions.outputs.release_tag }}"
-          
+
           if [ -z "$ARCHIVE_NAME" ]; then
             echo "❌ Error: archive_name is not set. Cannot create release."
             exit 1
           fi
-          
+
           if [ ! -f "${ARCHIVE_NAME}.zip" ] || [ ! -f "${ARCHIVE_NAME}.tar.gz" ]; then
             echo "❌ Error: Archive files not found. Expected: ${ARCHIVE_NAME}.zip and ${ARCHIVE_NAME}.tar.gz"
             exit 1
           fi
-          
+
           echo "🚀 Creating GitHub release: $RELEASE_TAG"
           echo "📎 Attaching archives: ${ARCHIVE_NAME}.zip, ${ARCHIVE_NAME}.tar.gz"
-          
+
           # Build release notes file
           {
             echo "## EEN OAuth Proxy Release"
             echo ""
-            echo "**Admin App Version:** ${{ steps.versions.outputs.admin_version }}"
-            echo "**Proxy Version:** ${{ steps.versions.outputs.proxy_version }}"
+            echo "**Admin App Version:** $ADMIN_VERSION"
+            echo "**Proxy Version:** $PROXY_VERSION"
             echo ""
             echo "### What's Changed"
             cat changelog.md
@@ -187,112 +197,73 @@ jobs:
           cat release_notes.md
 
           if ! gh release create "$RELEASE_TAG" \
-            --title "Proxy v${{ steps.versions.outputs.proxy_version }} / Admin v${{ steps.versions.outputs.admin_version }}" \
+            --title "Proxy v${PROXY_VERSION} / Admin v${ADMIN_VERSION}" \
             --notes-file release_notes.md \
             "${ARCHIVE_NAME}.zip" \
             "${ARCHIVE_NAME}.tar.gz"; then
             echo "❌ Error: Failed to create GitHub release"
             exit 1
           fi
-          
+
           echo "✅ Successfully created release: $RELEASE_TAG"
           echo "🔗 Release URL: https://github.com/${{ github.repository }}/releases/tag/$RELEASE_TAG"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Notify Slack
         if: steps.check_release.outputs.exists == 'false'
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          RELEASE_TAG: ${{ steps.versions.outputs.release_tag }}
+          PROXY_VERSION: ${{ steps.versions.outputs.proxy_version }}
+          ADMIN_VERSION: ${{ steps.versions.outputs.admin_version }}
         run: |
-          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${{ steps.versions.outputs.release_tag }}"
+          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${RELEASE_TAG}"
           RELEASE_TIME=$(TZ='America/Chicago' date +"%Y-%m-%d %H:%M:%S CT")
 
-          curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+          # Build JSON safely using jq to prevent injection via special characters
+          jq -n \
+            --arg title "New Release: Proxy v${PROXY_VERSION} / Admin v${ADMIN_VERSION}" \
+            --arg admin_ver "$ADMIN_VERSION" \
+            --arg proxy_ver "$PROXY_VERSION" \
+            --arg release_time "$RELEASE_TIME" \
+            --arg repo "${{ github.server_url }}/${{ github.repository }}" \
+            --arg repo_name "${{ github.repository }}" \
+            --arg admin_url "${{ vars.VITE_REDIRECT_URI }}" \
+            --arg proxy_url "${{ vars.VITE_PROXY_URL }}" \
+            --arg release_url "$RELEASE_URL" \
+            '{
+              blocks: [
+                {type: "header", text: {type: "plain_text", text: $title, emoji: true}},
+                {type: "section", fields: [
+                  {type: "mrkdwn", text: ("*Admin Version:*\n" + $admin_ver)},
+                  {type: "mrkdwn", text: ("*Proxy Version:*\n" + $proxy_ver)},
+                  {type: "mrkdwn", text: ("*Released:*\n" + $release_time)},
+                  {type: "mrkdwn", text: ("*Repository:*\n<" + $repo + "|" + $repo_name + ">")}
+                ]},
+                {type: "section", text: {type: "mrkdwn", text: ("*Deployed URLs:*\n• <" + $admin_url + "|Admin App>\n• <" + $proxy_url + "|OAuth Proxy>")}},
+                {type: "actions", elements: [
+                  {type: "button", text: {type: "plain_text", text: "View Release", emoji: true}, url: $release_url, style: "primary"},
+                  {type: "button", text: {type: "plain_text", text: "Release Notes", emoji: true}, url: $release_url}
+                ]},
+                {type: "context", elements: [{type: "mrkdwn", text: "Triggered by GitHub Actions \u2022 Workflow: Create Release"}]}
+              ]
+            }' | curl -sf -X POST "$SLACK_WEBHOOK" \
             -H "Content-Type: application/json" \
-            -d @- << EOF
-          {
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": "🚀 New Release: Proxy v${{ steps.versions.outputs.proxy_version }} / Admin v${{ steps.versions.outputs.admin_version }}",
-                  "emoji": true
-                }
-              },
-              {
-                "type": "section",
-                "fields": [
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Admin Version:*\n${{ steps.versions.outputs.admin_version }}"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Proxy Version:*\n${{ steps.versions.outputs.proxy_version }}"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Released:*\n${RELEASE_TIME}"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Repository:*\n<${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>"
-                  }
-                ]
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "*Deployed URLs:*\n• <${{ vars.VITE_REDIRECT_URI }}|Admin App>\n• <${{ vars.VITE_PROXY_URL }}|OAuth Proxy>"
-                }
-              },
-              {
-                "type": "actions",
-                "elements": [
-                  {
-                    "type": "button",
-                    "text": {
-                      "type": "plain_text",
-                      "text": "📦 View Release",
-                      "emoji": true
-                    },
-                    "url": "${RELEASE_URL}",
-                    "style": "primary"
-                  },
-                  {
-                    "type": "button",
-                    "text": {
-                      "type": "plain_text",
-                      "text": "📋 Release Notes",
-                      "emoji": true
-                    },
-                    "url": "${RELEASE_URL}"
-                  }
-                ]
-              },
-              {
-                "type": "context",
-                "elements": [
-                  {
-                    "type": "mrkdwn",
-                    "text": "Triggered by GitHub Actions • Workflow: Create Release"
-                  }
-                ]
-              }
-            ]
-          }
-          EOF
+            -d @-
           echo "✅ Slack notification sent"
 
       - name: Summary
+        env:
+          RELEASE_EXISTS: ${{ steps.check_release.outputs.exists }}
+          RELEASE_TAG: ${{ steps.versions.outputs.release_tag }}
+          ADMIN_VERSION: ${{ steps.versions.outputs.admin_version }}
+          PROXY_VERSION: ${{ steps.versions.outputs.proxy_version }}
         run: |
-          if [ "${{ steps.check_release.outputs.exists }}" = "true" ]; then
+          if [ "$RELEASE_EXISTS" = "true" ]; then
             echo "### ⏭️ Release Skipped" >> $GITHUB_STEP_SUMMARY
-            echo "Release ${{ steps.versions.outputs.release_tag }} already exists." >> $GITHUB_STEP_SUMMARY
+            echo "Release $RELEASE_TAG already exists." >> $GITHUB_STEP_SUMMARY
           else
             echo "### ✅ Release Created" >> $GITHUB_STEP_SUMMARY
-            echo "**Tag:** ${{ steps.versions.outputs.release_tag }}" >> $GITHUB_STEP_SUMMARY
-            echo "**Admin Version:** ${{ steps.versions.outputs.admin_version }}" >> $GITHUB_STEP_SUMMARY
-            echo "**Proxy Version:** ${{ steps.versions.outputs.proxy_version }}" >> $GITHUB_STEP_SUMMARY
+            echo "**Tag:** $RELEASE_TAG" >> $GITHUB_STEP_SUMMARY
+            echo "**Admin Version:** $ADMIN_VERSION" >> $GITHUB_STEP_SUMMARY
+            echo "**Proxy Version:** $PROXY_VERSION" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,8 @@ jobs:
           RELEASE_TAG: ${{ steps.versions.outputs.release_tag }}
           ADMIN_VERSION: ${{ steps.versions.outputs.admin_version }}
           PROXY_VERSION: ${{ steps.versions.outputs.proxy_version }}
+          ADMIN_URL: ${{ vars.VITE_REDIRECT_URI }}
+          PROXY_URL: ${{ vars.VITE_PROXY_URL }}
         run: |
           set -e
 
@@ -189,8 +191,8 @@ jobs:
             echo "- \`${ARCHIVE_NAME}.tar.gz\` - TAR.GZ archive"
             echo ""
             echo "### Deployed URLs"
-            echo "- **Admin App:** ${{ vars.VITE_REDIRECT_URI }}"
-            echo "- **Proxy:** ${{ vars.VITE_PROXY_URL }}"
+            echo "- **Admin App:** ${ADMIN_URL}"
+            echo "- **Proxy:** ${PROXY_URL}"
           } > release_notes.md
 
           echo "📝 Release notes:"
@@ -216,7 +218,10 @@ jobs:
           RELEASE_TAG: ${{ steps.versions.outputs.release_tag }}
           PROXY_VERSION: ${{ steps.versions.outputs.proxy_version }}
           ADMIN_VERSION: ${{ steps.versions.outputs.admin_version }}
+          ADMIN_URL: ${{ vars.VITE_REDIRECT_URI }}
+          PROXY_URL: ${{ vars.VITE_PROXY_URL }}
         run: |
+          set -o pipefail
           RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}"
           RELEASE_TIME=$(TZ='America/Chicago' date +"%Y-%m-%d %H:%M:%S CT")
 
@@ -228,8 +233,8 @@ jobs:
             --arg release_time "$RELEASE_TIME" \
             --arg repo "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
             --arg repo_name "$GITHUB_REPOSITORY" \
-            --arg admin_url "${{ vars.VITE_REDIRECT_URI }}" \
-            --arg proxy_url "${{ vars.VITE_PROXY_URL }}" \
+            --arg admin_url "$ADMIN_URL" \
+            --arg proxy_url "$PROXY_URL" \
             --arg release_url "$RELEASE_URL" \
             '{
               blocks: [


### PR DESCRIPTION
## Summary
- Move all `${{ steps.*.outputs.* }}` interpolations from shell `run:` blocks to `env:` blocks in `deploy-proxy.yml` and `release.yml`, preventing attacker-controlled values (git tags, package.json versions) from being interpreted as shell code during GitHub Actions template expansion
- Replace inline heredoc JSON in Slack notifications with `jq`-based construction for additional injection safety
- Move secrets from direct `${{ }}` interpolation to `env:` vars in the secrets deployment step

## Test plan
- [ ] Verify YAML lint passes (validated locally)
- [ ] Trigger `deploy-proxy.yml` via workflow_dispatch and confirm deployment succeeds with correct version string in KV
- [ ] Trigger `release.yml` via workflow_dispatch and confirm release is created with correct changelog, archives, and Slack notification
- [ ] Verify rollback path still works by intentionally failing verification step

🤖 Generated with [Claude Code](https://claude.com/claude-code)