### PR TITLE
fix: Add CORS headers to 403 origin rejections so clients can read the error

### DIFF
--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.18",
+  "version": "1.3.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.3.18",
+      "version": "1.3.19",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.18",
+  "version": "1.3.19",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -342,13 +342,25 @@ export default {
     // Validate origin
     const corsResult = validateOrigin(origin, env)
     if (!corsResult.valid) {
-      return new Response('Forbidden: Invalid origin', { status: 403 })
+      // Echo the rejected origin in CORS headers so the calling page can read
+      // this rejection instead of a generic CORS failure. This grants nothing:
+      // the body is static and every request re-validates the origin.
+      return addCorsHeaders(
+        new Response('Forbidden: Invalid origin', { status: 403 }),
+        origin || '*',
+        env
+      )
     }
 
     // CSRF protection: Require Origin header for state-changing requests
     // Requests without Origin (e.g., curl) are blocked for POST/DELETE to prevent CSRF
     if ((request.method === 'POST' || request.method === 'DELETE') && !origin) {
-      return new Response('Forbidden: Origin header required', { status: 403 })
+      // '*' (no credentials) lets a stripped-Origin client read the explanation
+      return addCorsHeaders(
+        new Response('Forbidden: Origin header required', { status: 403 }),
+        '*',
+        env
+      )
     }
 
     // Rate limiting check - applies to all requests including OPTIONS preflight

--- a/proxy/test/cors.test.js
+++ b/proxy/test/cors.test.js
@@ -14,6 +14,20 @@ describe('CORS validation', () => {
     expect(text).toContain('Forbidden')
   })
 
+  it('should include CORS headers on disallowed-origin rejections so clients can read the error', async () => {
+    const response = await fetchWithMetrics('http://localhost/health', {
+      headers: {
+        Origin: 'https://malicious-site.com'
+      }
+    })
+
+    expect(response.status).toBe(403)
+    // The rejected origin is echoed so the calling page can read the 403 body
+    // instead of seeing a generic CORS failure. This grants nothing: the body
+    // is a static string and every request re-validates the origin.
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://malicious-site.com')
+  })
+
   it('should allow requests from allowed origins', async () => {
     const response = await fetchWithMetrics('http://localhost/health', {
       headers: {

--- a/proxy/test/security.test.js
+++ b/proxy/test/security.test.js
@@ -241,9 +241,13 @@ describe('Security - CORS Bypass Attempts', () => {
     expect(response.status).toBeGreaterThanOrEqual(200)
 
     const allowOrigin = response.headers.get('Access-Control-Allow-Origin')
-    // Should not echo back malicious origins
-    if (allowOrigin && allowOrigin !== '*') {
-      expect(allowOrigin).not.toContain('evil.com')
+    // A disallowed origin may be echoed only on the static 403 rejection
+    // (lets the calling page read the error instead of a generic CORS
+    // failure) - never on a response carrying data
+    if (allowOrigin && allowOrigin !== '*' && allowOrigin.includes('evil.com')) {
+      expect(response.status).toBe(403)
+      const text = await response.text()
+      expect(text).toContain('Forbidden')
     }
   })
 })
@@ -790,6 +794,22 @@ describe('Security - CSRF Protection', () => {
     expect(response.status).toBe(403)
     const text = await response.text()
     expect(text).toContain('Origin header required')
+  })
+
+  it('should include CORS headers on Origin-required rejections so clients can read the error', async () => {
+    const response = await fetchWithMetrics(
+      'http://localhost/proxy/getAccessToken?code=test&redirect_uri=http://localhost:5173',
+      {
+        method: 'POST'
+        // No Origin header
+      }
+    )
+
+    expect(response.status).toBe(403)
+    // No origin to echo, so '*' lets a stripped-Origin client read the
+    // explanation. Credentials must not be allowed with a wildcard origin.
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
+    expect(response.headers.get('Access-Control-Allow-Credentials')).toBeNull()
   })
 
   it('should reject DELETE request without Origin header', async () => {


### PR DESCRIPTION
## Summary

Closes #125.

The worker's two bare-403 rejection paths — disallowed `Origin` and missing `Origin` on POST/DELETE — returned no CORS headers, so browsers hid the status and body from the calling page and reported only a generic CORS failure. A misconfigured allowlist, an Origin-stripping extension, and a Cloudflare edge error were indistinguishable from the outside.

## Changes

- **`proxy/src/index.js`**: both rejection paths now go through `addCorsHeaders()`:
  - Invalid origin → 403 echoing the rejected origin in `Access-Control-Allow-Origin`. This grants nothing: the body is a static string, a specific-origin ACAO only permits reading *this* response, and every request re-validates against `ALLOWED_ORIGINS`. (Also covers the production HTTPS-enforcement rejection inside `validateOrigin`.)
  - Missing Origin on POST/DELETE → 403 with ACAO `*`; `getCorsHeaders` already omits `Access-Control-Allow-Credentials` for `*`, so no credentialed-wildcard combination can arise.
- **`proxy/test/cors.test.js`**: new test asserting the disallowed-origin 403 echoes the rejected origin.
- **`proxy/test/security.test.js`**: new test asserting the no-Origin POST 403 carries ACAO `*` and no `Access-Control-Allow-Credentials`.
- **`proxy/test/security.test.js` (CORS Bypass Attempts)**: updated the blanket "never echo a malicious origin" assertion to the sharper invariant this change introduces: a disallowed origin may be echoed only on the static-body 403 rejection, never on a response carrying data. The new check also pins the status code, which the old one did not.

Preflight cannot be widened by this change: a 403 OPTIONS response fails preflight regardless of its headers (preflight requires an ok status).

Out of scope (per the issue): Cloudflare edge-level errors still surface without CORS headers — now identifiable by elimination.

## Test results

- proxy: 365 passed (vitest)
- admin: 18 passed (Playwright)
- demo1: 11 passed (Playwright)

## Versions

- proxy: 1.3.19
- admin: 1.1.4
- demo1: 0.1.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)