### PR TITLE
Release: CORS-readable 403 rejections (proxy v1.3.21) + CI workflow hardening

### DIFF
--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -330,6 +330,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           PACKAGE_VERSION: ${{ steps.version.outputs.version }}
         run: |
+          set -o pipefail
           # Build JSON safely using jq to prevent injection via special characters
           WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           jq -n \

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -60,11 +60,11 @@ jobs:
 
       - name: Check if deployment needed
         id: check
+        env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+          DEPLOYED_VERSION: ${{ steps.deployed.outputs.deployed_version }}
+          FORCE_DEPLOY: ${{ inputs.force_deploy }}
         run: |
-          PACKAGE_VERSION="${{ steps.version.outputs.version }}"
-          DEPLOYED_VERSION="${{ steps.deployed.outputs.deployed_version }}"
-          FORCE_DEPLOY="${{ inputs.force_deploy }}"
-
           if [ "$FORCE_DEPLOY" = "true" ]; then
             echo "::warning::Force deploy requested - bypassing version check"
             echo "should_deploy=true" >> $GITHUB_OUTPUT
@@ -78,10 +78,13 @@ jobs:
 
       - name: Skip deployment (versions match)
         if: steps.check.outputs.should_deploy == 'false'
+        env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+          DEPLOYED_VERSION: ${{ steps.deployed.outputs.deployed_version }}
         run: |
           echo "## Deployment Skipped" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Package version (${{ steps.version.outputs.version }}) matches deployed version (${{ steps.deployed.outputs.deployed_version }})." >> $GITHUB_STEP_SUMMARY
+          echo "Package version ($PACKAGE_VERSION) matches deployed version ($DEPLOYED_VERSION)." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Use **force_deploy** input to deploy anyway (use with caution)." >> $GITHUB_STEP_SUMMARY
 
@@ -128,28 +131,35 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          SECRET_CLIENT_ID: ${{ secrets.VITE_EEN_CLIENT_ID }}
+          SECRET_CLIENT_SECRET: ${{ secrets.EEN_CLIENT_SECRET }}
+          SECRET_ADMIN_EMAILS: ${{ secrets.ADMIN_EMAILS }}
+          SECRET_ALLOWED_ORIGINS: ${{ secrets.ALLOWED_ORIGINS }}
+          SECRET_ALLOWED_API_DOMAINS: ${{ secrets.ALLOWED_API_DOMAINS }}
+          SECRET_REFRESH_TOKEN_TTL: ${{ secrets.REFRESH_TOKEN_TTL }}
+          SECRET_MAX_KV_KEYS: ${{ secrets.MAX_KV_KEYS }}
         run: |
           cd proxy
           echo "Setting CLIENT_ID..."
-          printf '%s' "${{ secrets.VITE_EEN_CLIENT_ID }}" | npx wrangler secret put CLIENT_ID
+          printf '%s' "$SECRET_CLIENT_ID" | npx wrangler secret put CLIENT_ID
 
           echo "Setting CLIENT_SECRET..."
-          printf '%s' "${{ secrets.EEN_CLIENT_SECRET }}" | npx wrangler secret put CLIENT_SECRET
+          printf '%s' "$SECRET_CLIENT_SECRET" | npx wrangler secret put CLIENT_SECRET
 
           echo "Setting ADMIN_EMAILS..."
-          printf '%s' "${{ secrets.ADMIN_EMAILS }}" | npx wrangler secret put ADMIN_EMAILS
+          printf '%s' "$SECRET_ADMIN_EMAILS" | npx wrangler secret put ADMIN_EMAILS
 
           echo "Setting ALLOWED_ORIGINS..."
-          printf '%s' "${{ secrets.ALLOWED_ORIGINS }}" | npx wrangler secret put ALLOWED_ORIGINS
+          printf '%s' "$SECRET_ALLOWED_ORIGINS" | npx wrangler secret put ALLOWED_ORIGINS
 
           echo "Setting ALLOWED_API_DOMAINS..."
-          printf '%s' "${{ secrets.ALLOWED_API_DOMAINS }}" | npx wrangler secret put ALLOWED_API_DOMAINS
+          printf '%s' "$SECRET_ALLOWED_API_DOMAINS" | npx wrangler secret put ALLOWED_API_DOMAINS
 
           echo "Setting REFRESH_TOKEN_TTL..."
-          printf '%s' "${{ secrets.REFRESH_TOKEN_TTL }}" | npx wrangler secret put REFRESH_TOKEN_TTL
+          printf '%s' "$SECRET_REFRESH_TOKEN_TTL" | npx wrangler secret put REFRESH_TOKEN_TTL
 
           echo "Setting MAX_KV_KEYS..."
-          printf '%s' "${{ secrets.MAX_KV_KEYS }}" | npx wrangler secret put MAX_KV_KEYS
+          printf '%s' "$SECRET_MAX_KV_KEYS" | npx wrangler secret put MAX_KV_KEYS
 
       - name: Store deploy version in KV
         if: steps.check.outputs.should_deploy == 'true'
@@ -157,10 +167,11 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
         run: |
           cd proxy
           DEPLOY_TIME=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
-          VERSION_STRING="een-oauth-proxy - ${{ steps.version.outputs.version }} - $DEPLOY_TIME"
+          VERSION_STRING="een-oauth-proxy - ${PACKAGE_VERSION} - $DEPLOY_TIME"
           # Get namespace ID from wrangler.toml (look for id within 10 lines after kv_namespaces section)
           NAMESPACE_ID=$(grep -A 10 '\[\[kv_namespaces\]\]' wrangler.toml | grep 'id = "' | head -1 | sed 's/.*id = "\([^"]*\)".*/\1/')
           # Validate namespace ID was found and has correct format (32-char hex)
@@ -179,11 +190,13 @@ jobs:
       - name: Wait for deployment propagation
         if: steps.check.outputs.should_deploy == 'true'
         id: wait_propagation
+        env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
         run: |
           # Poll health endpoint until version matches or timeout (exponential backoff)
           # Note: Health endpoint returns full version string like "een-oauth-proxy - 1.2.37 - timestamp"
           # so we check if the expected version number is contained in the response
-          EXPECTED_VERSION="${{ steps.version.outputs.version }}"
+          EXPECTED_VERSION="$PACKAGE_VERSION"
           MAX_ATTEMPTS=6
           WAIT_TIME=5
 
@@ -216,6 +229,14 @@ jobs:
       - name: Check rollback conditions
         if: always() && steps.check.outputs.should_deploy == 'true'
         id: rollback_check
+        env:
+          DEPLOY_SUCCEEDED: ${{ steps.deploy.outputs.deployed == 'true' }}
+          SECRETS_FAILED: ${{ steps.set_secrets.outcome == 'failure' }}
+          STORE_VERSION_FAILED: ${{ steps.store_version.outcome == 'failure' }}
+          PROPAGATION_FAILED: ${{ steps.wait_propagation.outcome == 'failure' }}
+          VERIFY_FAILED: ${{ steps.verify.outcome == 'failure' }}
+          DEPLOYMENT_COMPLETE: ${{ steps.store_version.outputs.deployment_complete == 'true' }}
+          HAS_PREVIOUS: ${{ steps.current_deployment.outputs.has_previous_version == 'true' }}
         run: |
           # Determine if rollback should be attempted
           # Rollback triggers if deploy succeeded but any post-deployment step failed:
@@ -224,13 +245,6 @@ jobs:
           # - propagation wait failed, OR
           # - verification failed, OR
           # - deployment_complete flag not set
-          DEPLOY_SUCCEEDED="${{ steps.deploy.outputs.deployed == 'true' }}"
-          SECRETS_FAILED="${{ steps.set_secrets.outcome == 'failure' }}"
-          STORE_VERSION_FAILED="${{ steps.store_version.outcome == 'failure' }}"
-          PROPAGATION_FAILED="${{ steps.wait_propagation.outcome == 'failure' }}"
-          VERIFY_FAILED="${{ steps.verify.outcome == 'failure' }}"
-          DEPLOYMENT_COMPLETE="${{ steps.store_version.outputs.deployment_complete == 'true' }}"
-          HAS_PREVIOUS="${{ steps.current_deployment.outputs.has_previous_version == 'true' }}"
 
           echo "Deploy succeeded: $DEPLOY_SUCCEEDED"
           echo "Secrets failed: $SECRETS_FAILED"
@@ -266,9 +280,9 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ROLLBACK_VERSION: ${{ steps.current_deployment.outputs.version_id }}
         run: |
           cd proxy
-          ROLLBACK_VERSION="${{ steps.current_deployment.outputs.version_id }}"
           echo "::error::Verification failed! Rolling back to version: $ROLLBACK_VERSION"
           npx wrangler versions deploy "$ROLLBACK_VERSION" --yes
           echo "rollback_performed=true" >> $GITHUB_OUTPUT
@@ -298,11 +312,14 @@ jobs:
 
       - name: Deployment summary
         if: steps.check.outputs.should_deploy == 'true' && success()
+        env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+          DEPLOYED_VERSION: ${{ steps.deployed.outputs.deployed_version }}
         run: |
           echo "## Proxy Deployment Complete" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Previous:** ${{ steps.deployed.outputs.deployed_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** $PACKAGE_VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "**Previous:** $DEPLOYED_VERSION" >> $GITHUB_STEP_SUMMARY
           echo "**Worker:** een-oauth-proxy" >> $GITHUB_STEP_SUMMARY
           echo "**URL:** $PROXY_URL" >> $GITHUB_STEP_SUMMARY
 
@@ -311,87 +328,55 @@ jobs:
         continue-on-error: true
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          # Use env var to prevent webhook URL exposure in error output
-          # Note: Admin App URL is /een-oauth-proxy (not /een-oauth-proxy/admin/) - GitHub Pages serves it from base path
-          curl -sf -X POST "$SLACK_WEBHOOK" \
-            -H "Content-Type: application/json" \
-            -d '{
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "Proxy Deployed to Cloudflare",
-                    "emoji": true
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Version:*\n${{ steps.version.outputs.version }}"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Status:*\n:white_check_mark: Success"
-                    }
-                  ]
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "Health Check"
-                      },
-                      "url": "'"$PROXY_URL"'/health"
-                    },
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "Admin App"
-                      },
-                      "url": "https://klaushofrichter.github.io/een-oauth-proxy"
-                    },
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "View Workflow"
-                      },
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
+          # Build JSON safely using jq to prevent injection via special characters
+          WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          jq -n \
+            --arg version "$PACKAGE_VERSION" \
+            --arg health_url "${PROXY_URL}/health" \
+            --arg workflow_url "$WORKFLOW_URL" \
+            '{
+              blocks: [
+                {type: "header", text: {type: "plain_text", text: "Proxy Deployed to Cloudflare", emoji: true}},
+                {type: "section", fields: [
+                  {type: "mrkdwn", text: ("*Version:*\n" + $version)},
+                  {type: "mrkdwn", text: "*Status:*\n:white_check_mark: Success"}
+                ]},
+                {type: "actions", elements: [
+                  {type: "button", text: {type: "plain_text", text: "Health Check"}, url: $health_url},
+                  {type: "button", text: {type: "plain_text", text: "Admin App"}, url: "https://klaushofrichter.github.io/een-oauth-proxy"},
+                  {type: "button", text: {type: "plain_text", text: "View Workflow"}, url: $workflow_url}
+                ]}
               ]
-            }'
+            }' | curl -sf -X POST "$SLACK_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d @-
 
       - name: Notify Slack on failure
         if: failure()
         continue-on-error: true
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+          ROLLBACK_PERFORMED: ${{ steps.rollback.outputs.rollback_performed }}
+          PREVIOUS_VERSION_ID: ${{ steps.current_deployment.outputs.version_id }}
+          HAS_PREVIOUS_VERSION: ${{ steps.current_deployment.outputs.has_previous_version }}
         run: |
           set -o pipefail
-          VERSION="${{ steps.version.outputs.version }}"
-          VERSION="${VERSION:-unknown}"
+          VERSION="${PACKAGE_VERSION:-unknown}"
           ROLLBACK_STATUS=""
-          if [ "${{ steps.rollback.outputs.rollback_performed }}" = "true" ]; then
-            ROLLBACK_STATUS=" (rolled back to ${{ steps.current_deployment.outputs.version_id }})"
-          elif [ "${{ steps.current_deployment.outputs.has_previous_version }}" != "true" ]; then
+          if [ "$ROLLBACK_PERFORMED" = "true" ]; then
+            ROLLBACK_STATUS=" (rolled back to ${PREVIOUS_VERSION_ID})"
+          elif [ "$HAS_PREVIOUS_VERSION" != "true" ]; then
             ROLLBACK_STATUS=" (rollback not possible - no previous version)"
           fi
           # Build JSON safely using jq to prevent injection via special characters
-          # Use env var to prevent webhook URL exposure in error output
+          WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           jq -n \
             --arg title "Proxy Deployment Failed${ROLLBACK_STATUS}" \
             --arg version "$VERSION" \
-            --arg url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --arg url "$WORKFLOW_URL" \
             '{
               blocks: [
                 {type: "header", text: {type: "plain_text", text: $title, emoji: true}},

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -331,7 +331,7 @@ jobs:
           PACKAGE_VERSION: ${{ steps.version.outputs.version }}
         run: |
           # Build JSON safely using jq to prevent injection via special characters
-          WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           jq -n \
             --arg version "$PACKAGE_VERSION" \
             --arg health_url "${PROXY_URL}/health" \
@@ -372,7 +372,7 @@ jobs:
             ROLLBACK_STATUS=" (rollback not possible - no previous version)"
           fi
           # Build JSON safely using jq to prevent injection via special characters
-          WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           jq -n \
             --arg title "Proxy Deployment Failed${ROLLBACK_STATUS}" \
             --arg version "$VERSION" \

--- a/.github/workflows/pr-review-gemini.yml
+++ b/.github/workflows/pr-review-gemini.yml
@@ -100,6 +100,10 @@ jobs:
         id: gemini-review
         continue-on-error: true  # Informational only - don't fail PR on API errors
         uses: google-github-actions/run-gemini-cli@v0
+        env:
+          # The CLI refuses headless runs in untrusted directories, which made
+          # every review come back "unavailable"
+          GEMINI_CLI_TRUST_WORKSPACE: "true"
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           gemini_model: "gemini-3-flash-preview"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -49,6 +49,9 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # The Claude PR Steward bot pushes fixes to PR branches; without this
+          # the action refuses runs triggered by its pushes (non-human actor)
+          allowed_bots: "claude"
           prompt: |
             Please review this pull request and provide constructive feedback on:
             1. Code quality and best practices

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Generate changelog
         if: steps.check_release.outputs.exists == 'false'
         run: |
-          REPO_URL="https://github.com/${{ github.repository }}"
+          REPO_URL="https://github.com/${GITHUB_REPOSITORY}"
           if [ "$HAS_PREV" = "true" ]; then
             ./scripts/generate-changelog.sh "$REPO_URL" "$PREV_TAG"
           else
@@ -206,17 +206,18 @@ jobs:
           fi
 
           echo "✅ Successfully created release: $RELEASE_TAG"
-          echo "🔗 Release URL: https://github.com/${{ github.repository }}/releases/tag/$RELEASE_TAG"
+          echo "🔗 Release URL: https://github.com/${GITHUB_REPOSITORY}/releases/tag/$RELEASE_TAG"
 
       - name: Notify Slack
         if: steps.check_release.outputs.exists == 'false'
+        continue-on-error: true
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           RELEASE_TAG: ${{ steps.versions.outputs.release_tag }}
           PROXY_VERSION: ${{ steps.versions.outputs.proxy_version }}
           ADMIN_VERSION: ${{ steps.versions.outputs.admin_version }}
         run: |
-          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${RELEASE_TAG}"
+          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}"
           RELEASE_TIME=$(TZ='America/Chicago' date +"%Y-%m-%d %H:%M:%S CT")
 
           # Build JSON safely using jq to prevent injection via special characters
@@ -225,8 +226,8 @@ jobs:
             --arg admin_ver "$ADMIN_VERSION" \
             --arg proxy_ver "$PROXY_VERSION" \
             --arg release_time "$RELEASE_TIME" \
-            --arg repo "${{ github.server_url }}/${{ github.repository }}" \
-            --arg repo_name "${{ github.repository }}" \
+            --arg repo "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+            --arg repo_name "$GITHUB_REPOSITORY" \
             --arg admin_url "${{ vars.VITE_REDIRECT_URI }}" \
             --arg proxy_url "${{ vars.VITE_PROXY_URL }}" \
             --arg release_url "$RELEASE_URL" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,9 +58,8 @@ jobs:
         id: check_release
         run: |
           set -e
-          RELEASE_TAG="${{ steps.versions.outputs.release_tag }}"
           echo "🔍 Checking if release '$RELEASE_TAG' already exists..."
-          
+
           if gh release view "$RELEASE_TAG" > /dev/null 2>&1; then
             echo "exists=true" >> $GITHUB_OUTPUT
             echo "ℹ️ Release $RELEASE_TAG already exists, skipping creation"
@@ -70,6 +69,7 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.versions.outputs.release_tag }}
 
       - name: Get previous release tag
         id: prev_tag
@@ -102,18 +102,24 @@ jobs:
         if: steps.check_release.outputs.exists == 'false'
         run: |
           REPO_URL="https://github.com/${{ github.repository }}"
-          if [ "${{ steps.prev_tag.outputs.has_prev }}" = "true" ]; then
-            ./scripts/generate-changelog.sh "$REPO_URL" "${{ steps.prev_tag.outputs.prev_tag }}"
+          if [ "$HAS_PREV" = "true" ]; then
+            ./scripts/generate-changelog.sh "$REPO_URL" "$PREV_TAG"
           else
             ./scripts/generate-changelog.sh "$REPO_URL"
           fi
+        env:
+          HAS_PREV: ${{ steps.prev_tag.outputs.has_prev }}
+          PREV_TAG: ${{ steps.prev_tag.outputs.prev_tag }}
 
       - name: Create release archive
         id: create_archive
         if: steps.check_release.outputs.exists == 'false'
+        env:
+          PROXY_VERSION: ${{ steps.versions.outputs.proxy_version }}
+          ADMIN_VERSION: ${{ steps.versions.outputs.admin_version }}
         run: |
           set -e
-          ARCHIVE_NAME="een-oauth-proxy-v${{ steps.versions.outputs.proxy_version }}_v${{ steps.versions.outputs.admin_version }}"
+          ARCHIVE_NAME="een-oauth-proxy-v${PROXY_VERSION}_v${ADMIN_VERSION}"
           echo "📦 Creating release archives with name: $ARCHIVE_NAME"
           
           echo "Creating ZIP archive..."
@@ -146,30 +152,34 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.check_release.outputs.exists == 'false' && steps.create_archive.outputs.archive_name != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARCHIVE_NAME: ${{ steps.create_archive.outputs.archive_name }}
+          RELEASE_TAG: ${{ steps.versions.outputs.release_tag }}
+          ADMIN_VERSION: ${{ steps.versions.outputs.admin_version }}
+          PROXY_VERSION: ${{ steps.versions.outputs.proxy_version }}
         run: |
           set -e
-          ARCHIVE_NAME="${{ steps.create_archive.outputs.archive_name }}"
-          RELEASE_TAG="${{ steps.versions.outputs.release_tag }}"
-          
+
           if [ -z "$ARCHIVE_NAME" ]; then
             echo "❌ Error: archive_name is not set. Cannot create release."
             exit 1
           fi
-          
+
           if [ ! -f "${ARCHIVE_NAME}.zip" ] || [ ! -f "${ARCHIVE_NAME}.tar.gz" ]; then
             echo "❌ Error: Archive files not found. Expected: ${ARCHIVE_NAME}.zip and ${ARCHIVE_NAME}.tar.gz"
             exit 1
           fi
-          
+
           echo "🚀 Creating GitHub release: $RELEASE_TAG"
           echo "📎 Attaching archives: ${ARCHIVE_NAME}.zip, ${ARCHIVE_NAME}.tar.gz"
-          
+
           # Build release notes file
           {
             echo "## EEN OAuth Proxy Release"
             echo ""
-            echo "**Admin App Version:** ${{ steps.versions.outputs.admin_version }}"
-            echo "**Proxy Version:** ${{ steps.versions.outputs.proxy_version }}"
+            echo "**Admin App Version:** $ADMIN_VERSION"
+            echo "**Proxy Version:** $PROXY_VERSION"
             echo ""
             echo "### What's Changed"
             cat changelog.md
@@ -187,112 +197,73 @@ jobs:
           cat release_notes.md
 
           if ! gh release create "$RELEASE_TAG" \
-            --title "Proxy v${{ steps.versions.outputs.proxy_version }} / Admin v${{ steps.versions.outputs.admin_version }}" \
+            --title "Proxy v${PROXY_VERSION} / Admin v${ADMIN_VERSION}" \
             --notes-file release_notes.md \
             "${ARCHIVE_NAME}.zip" \
             "${ARCHIVE_NAME}.tar.gz"; then
             echo "❌ Error: Failed to create GitHub release"
             exit 1
           fi
-          
+
           echo "✅ Successfully created release: $RELEASE_TAG"
           echo "🔗 Release URL: https://github.com/${{ github.repository }}/releases/tag/$RELEASE_TAG"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Notify Slack
         if: steps.check_release.outputs.exists == 'false'
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          RELEASE_TAG: ${{ steps.versions.outputs.release_tag }}
+          PROXY_VERSION: ${{ steps.versions.outputs.proxy_version }}
+          ADMIN_VERSION: ${{ steps.versions.outputs.admin_version }}
         run: |
-          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${{ steps.versions.outputs.release_tag }}"
+          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${RELEASE_TAG}"
           RELEASE_TIME=$(TZ='America/Chicago' date +"%Y-%m-%d %H:%M:%S CT")
 
-          curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+          # Build JSON safely using jq to prevent injection via special characters
+          jq -n \
+            --arg title "New Release: Proxy v${PROXY_VERSION} / Admin v${ADMIN_VERSION}" \
+            --arg admin_ver "$ADMIN_VERSION" \
+            --arg proxy_ver "$PROXY_VERSION" \
+            --arg release_time "$RELEASE_TIME" \
+            --arg repo "${{ github.server_url }}/${{ github.repository }}" \
+            --arg repo_name "${{ github.repository }}" \
+            --arg admin_url "${{ vars.VITE_REDIRECT_URI }}" \
+            --arg proxy_url "${{ vars.VITE_PROXY_URL }}" \
+            --arg release_url "$RELEASE_URL" \
+            '{
+              blocks: [
+                {type: "header", text: {type: "plain_text", text: $title, emoji: true}},
+                {type: "section", fields: [
+                  {type: "mrkdwn", text: ("*Admin Version:*\n" + $admin_ver)},
+                  {type: "mrkdwn", text: ("*Proxy Version:*\n" + $proxy_ver)},
+                  {type: "mrkdwn", text: ("*Released:*\n" + $release_time)},
+                  {type: "mrkdwn", text: ("*Repository:*\n<" + $repo + "|" + $repo_name + ">")}
+                ]},
+                {type: "section", text: {type: "mrkdwn", text: ("*Deployed URLs:*\n• <" + $admin_url + "|Admin App>\n• <" + $proxy_url + "|OAuth Proxy>")}},
+                {type: "actions", elements: [
+                  {type: "button", text: {type: "plain_text", text: "View Release", emoji: true}, url: $release_url, style: "primary"},
+                  {type: "button", text: {type: "plain_text", text: "Release Notes", emoji: true}, url: $release_url}
+                ]},
+                {type: "context", elements: [{type: "mrkdwn", text: "Triggered by GitHub Actions \u2022 Workflow: Create Release"}]}
+              ]
+            }' | curl -sf -X POST "$SLACK_WEBHOOK" \
             -H "Content-Type: application/json" \
-            -d @- << EOF
-          {
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": "🚀 New Release: Proxy v${{ steps.versions.outputs.proxy_version }} / Admin v${{ steps.versions.outputs.admin_version }}",
-                  "emoji": true
-                }
-              },
-              {
-                "type": "section",
-                "fields": [
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Admin Version:*\n${{ steps.versions.outputs.admin_version }}"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Proxy Version:*\n${{ steps.versions.outputs.proxy_version }}"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Released:*\n${RELEASE_TIME}"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Repository:*\n<${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>"
-                  }
-                ]
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "*Deployed URLs:*\n• <${{ vars.VITE_REDIRECT_URI }}|Admin App>\n• <${{ vars.VITE_PROXY_URL }}|OAuth Proxy>"
-                }
-              },
-              {
-                "type": "actions",
-                "elements": [
-                  {
-                    "type": "button",
-                    "text": {
-                      "type": "plain_text",
-                      "text": "📦 View Release",
-                      "emoji": true
-                    },
-                    "url": "${RELEASE_URL}",
-                    "style": "primary"
-                  },
-                  {
-                    "type": "button",
-                    "text": {
-                      "type": "plain_text",
-                      "text": "📋 Release Notes",
-                      "emoji": true
-                    },
-                    "url": "${RELEASE_URL}"
-                  }
-                ]
-              },
-              {
-                "type": "context",
-                "elements": [
-                  {
-                    "type": "mrkdwn",
-                    "text": "Triggered by GitHub Actions • Workflow: Create Release"
-                  }
-                ]
-              }
-            ]
-          }
-          EOF
+            -d @-
           echo "✅ Slack notification sent"
 
       - name: Summary
+        env:
+          RELEASE_EXISTS: ${{ steps.check_release.outputs.exists }}
+          RELEASE_TAG: ${{ steps.versions.outputs.release_tag }}
+          ADMIN_VERSION: ${{ steps.versions.outputs.admin_version }}
+          PROXY_VERSION: ${{ steps.versions.outputs.proxy_version }}
         run: |
-          if [ "${{ steps.check_release.outputs.exists }}" = "true" ]; then
+          if [ "$RELEASE_EXISTS" = "true" ]; then
             echo "### ⏭️ Release Skipped" >> $GITHUB_STEP_SUMMARY
-            echo "Release ${{ steps.versions.outputs.release_tag }} already exists." >> $GITHUB_STEP_SUMMARY
+            echo "Release $RELEASE_TAG already exists." >> $GITHUB_STEP_SUMMARY
           else
             echo "### ✅ Release Created" >> $GITHUB_STEP_SUMMARY
-            echo "**Tag:** ${{ steps.versions.outputs.release_tag }}" >> $GITHUB_STEP_SUMMARY
-            echo "**Admin Version:** ${{ steps.versions.outputs.admin_version }}" >> $GITHUB_STEP_SUMMARY
-            echo "**Proxy Version:** ${{ steps.versions.outputs.proxy_version }}" >> $GITHUB_STEP_SUMMARY
+            echo "**Tag:** $RELEASE_TAG" >> $GITHUB_STEP_SUMMARY
+            echo "**Admin Version:** $ADMIN_VERSION" >> $GITHUB_STEP_SUMMARY
+            echo "**Proxy Version:** $PROXY_VERSION" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,8 @@ jobs:
           RELEASE_TAG: ${{ steps.versions.outputs.release_tag }}
           ADMIN_VERSION: ${{ steps.versions.outputs.admin_version }}
           PROXY_VERSION: ${{ steps.versions.outputs.proxy_version }}
+          ADMIN_URL: ${{ vars.VITE_REDIRECT_URI }}
+          PROXY_URL: ${{ vars.VITE_PROXY_URL }}
         run: |
           set -e
 
@@ -189,8 +191,8 @@ jobs:
             echo "- \`${ARCHIVE_NAME}.tar.gz\` - TAR.GZ archive"
             echo ""
             echo "### Deployed URLs"
-            echo "- **Admin App:** ${{ vars.VITE_REDIRECT_URI }}"
-            echo "- **Proxy:** ${{ vars.VITE_PROXY_URL }}"
+            echo "- **Admin App:** ${ADMIN_URL}"
+            echo "- **Proxy:** ${PROXY_URL}"
           } > release_notes.md
 
           echo "📝 Release notes:"
@@ -216,7 +218,10 @@ jobs:
           RELEASE_TAG: ${{ steps.versions.outputs.release_tag }}
           PROXY_VERSION: ${{ steps.versions.outputs.proxy_version }}
           ADMIN_VERSION: ${{ steps.versions.outputs.admin_version }}
+          ADMIN_URL: ${{ vars.VITE_REDIRECT_URI }}
+          PROXY_URL: ${{ vars.VITE_PROXY_URL }}
         run: |
+          set -o pipefail
           RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}"
           RELEASE_TIME=$(TZ='America/Chicago' date +"%Y-%m-%d %H:%M:%S CT")
 
@@ -228,8 +233,8 @@ jobs:
             --arg release_time "$RELEASE_TIME" \
             --arg repo "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
             --arg repo_name "$GITHUB_REPOSITORY" \
-            --arg admin_url "${{ vars.VITE_REDIRECT_URI }}" \
-            --arg proxy_url "${{ vars.VITE_PROXY_URL }}" \
+            --arg admin_url "$ADMIN_URL" \
+            --arg proxy_url "$PROXY_URL" \
             --arg release_url "$RELEASE_URL" \
             '{
               blocks: [

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.3.20",
+      "version": "1.3.21",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.3.19",
+      "version": "1.3.20",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.18",
+  "version": "1.3.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-proxy",
-      "version": "1.3.18",
+      "version": "1.3.19",
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.9.12",
         "dotenv": "^17.2.3",

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.18",
+  "version": "1.3.19",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "een-oauth-proxy",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -344,10 +344,12 @@ export default {
     if (!corsResult.valid) {
       // Echo the rejected origin in CORS headers so the calling page can read
       // this rejection instead of a generic CORS failure. This grants nothing:
-      // the body is static and every request re-validates the origin.
+      // every request re-validates the origin, and validateOrigin only rejects
+      // non-empty origins, so origin is always set here.
+      // SECURITY: keep this body static - it is readable cross-origin with credentials
       return addCorsHeaders(
         new Response('Forbidden: Invalid origin', { status: 403 }),
-        origin || '*',
+        origin,
         env
       )
     }
@@ -1296,6 +1298,8 @@ function getCorsHeaders(origin, env = null) {
     'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type, Authorization, Cookie',
     'Access-Control-Max-Age': '86400',
+    // Responses differ per Origin, so caches must key on it
+    'Vary': 'Origin',
     // Security headers
     'X-Content-Type-Options': 'nosniff',
     'X-Frame-Options': 'DENY',

--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -342,13 +342,25 @@ export default {
     // Validate origin
     const corsResult = validateOrigin(origin, env)
     if (!corsResult.valid) {
-      return new Response('Forbidden: Invalid origin', { status: 403 })
+      // Echo the rejected origin in CORS headers so the calling page can read
+      // this rejection instead of a generic CORS failure. This grants nothing:
+      // the body is static and every request re-validates the origin.
+      return addCorsHeaders(
+        new Response('Forbidden: Invalid origin', { status: 403 }),
+        origin || '*',
+        env
+      )
     }
 
     // CSRF protection: Require Origin header for state-changing requests
     // Requests without Origin (e.g., curl) are blocked for POST/DELETE to prevent CSRF
     if ((request.method === 'POST' || request.method === 'DELETE') && !origin) {
-      return new Response('Forbidden: Origin header required', { status: 403 })
+      // '*' (no credentials) lets a stripped-Origin client read the explanation
+      return addCorsHeaders(
+        new Response('Forbidden: Origin header required', { status: 403 }),
+        '*',
+        env
+      )
     }
 
     // Rate limiting check - applies to all requests including OPTIONS preflight

--- a/proxy/test/cors.test.js
+++ b/proxy/test/cors.test.js
@@ -14,6 +14,20 @@ describe('CORS validation', () => {
     expect(text).toContain('Forbidden')
   })
 
+  it('should include CORS headers on disallowed-origin rejections so clients can read the error', async () => {
+    const response = await fetchWithMetrics('http://localhost/health', {
+      headers: {
+        Origin: 'https://malicious-site.com'
+      }
+    })
+
+    expect(response.status).toBe(403)
+    // The rejected origin is echoed so the calling page can read the 403 body
+    // instead of seeing a generic CORS failure. This grants nothing: the body
+    // is a static string and every request re-validates the origin.
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://malicious-site.com')
+  })
+
   it('should allow requests from allowed origins', async () => {
     const response = await fetchWithMetrics('http://localhost/health', {
       headers: {

--- a/proxy/test/cors.test.js
+++ b/proxy/test/cors.test.js
@@ -28,6 +28,18 @@ describe('CORS validation', () => {
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://malicious-site.com')
   })
 
+  it('should include Vary: Origin so caches never serve one origin\'s CORS headers to another', async () => {
+    const allowed = await fetchWithMetrics('http://localhost/health', {
+      headers: { Origin: 'http://localhost:5173' }
+    })
+    expect(allowed.headers.get('Vary')).toBe('Origin')
+
+    const rejected = await fetchWithMetrics('http://localhost/health', {
+      headers: { Origin: 'https://malicious-site.com' }
+    })
+    expect(rejected.headers.get('Vary')).toBe('Origin')
+  })
+
   it('should allow requests from allowed origins', async () => {
     const response = await fetchWithMetrics('http://localhost/health', {
       headers: {

--- a/proxy/test/security.test.js
+++ b/proxy/test/security.test.js
@@ -211,46 +211,42 @@ describe('Security - Session Management', () => {
 
 describe('Security - CORS Bypass Attempts', () => {
   const bypassAttempts = [
-    // Null origin
+    // Disallowed origins: must get the static 403 rejection. The proxy
+    // echoes the rejected origin so the caller can read the error - that
+    // echo is only ever permitted on this static 403, never on a data response.
     { origin: 'null', description: 'null origin' },
-    // Origin with trailing characters
-    { origin: 'http://localhost:5173.evil.com', description: 'subdomain trick', disallowedEcho: true },
-    // Origin manipulation
-    { origin: 'http://localhost:5173%00.evil.com', description: 'null byte in origin', disallowedEcho: true },
-    // Case sensitivity
+    { origin: 'http://localhost:5173.evil.com', description: 'subdomain trick' },
+    { origin: 'http://localhost:5173%00.evil.com', description: 'null byte in origin' },
     { origin: 'HTTP://LOCALHOST:5173', description: 'uppercase origin' },
-    // Whitespace
-    { origin: ' http://localhost:5173', description: 'leading whitespace' },
-    { origin: 'http://localhost:5173 ', description: 'trailing whitespace' },
-    // Protocol manipulation
     { origin: 'https://localhost:5173', description: 'https instead of http' },
-    // Port manipulation
     { origin: 'http://localhost:5174', description: 'different port' },
-    // Host manipulation
     { origin: 'http://127.0.0.1:5173', description: 'IP instead of localhost' },
+    // The Headers API strips leading/trailing whitespace from header values,
+    // so these arrive as the allowed origin and must proceed past origin
+    // validation, reflecting only the exact allowlisted value
+    { origin: ' http://localhost:5173', description: 'leading whitespace', normalizesToAllowed: true },
+    { origin: 'http://localhost:5173 ', description: 'trailing whitespace', normalizesToAllowed: true },
   ]
 
-  it.each(bypassAttempts)('should handle origin: $description', async ({ origin, disallowedEcho }) => {
+  it.each(bypassAttempts)('should handle origin: $description', async ({ origin, normalizesToAllowed }) => {
     const response = await fetchWithMetrics('http://localhost/proxy/getAccessToken?code=test&redirect_uri=http://test.com', {
       method: 'POST',
       headers: { Origin: origin }
     })
 
-    // Either forbidden (403) or the request proceeds with proper CORS headers
-    // The key is it shouldn't crash and shouldn't allow unauthorized origins
-    expect(response.status).toBeGreaterThanOrEqual(200)
-
-    // A disallowed origin may be echoed only on the static 403 rejection
-    // (lets the calling page read the error instead of a generic CORS
-    // failure) - never on a response carrying data. Match the echoed value
-    // exactly against the request origin rather than substring-scanning it.
-    if (disallowedEcho) {
-      const allowOrigin = response.headers.get('Access-Control-Allow-Origin')
-      if (allowOrigin === origin) {
-        expect(response.status).toBe(403)
-        const text = await response.text()
-        expect(text).toContain('Forbidden')
-      }
+    const allowOrigin = response.headers.get('Access-Control-Allow-Origin')
+    if (normalizesToAllowed) {
+      // Proceeds past origin validation (may still fail later for other
+      // reasons, but never as an origin rejection) and the reflected origin
+      // is exactly the allowlisted value
+      expect(response.status).not.toBe(403)
+      expect(allowOrigin).toBe('http://localhost:5173')
+    } else {
+      // The static 403 rejection, echoing exactly the rejected origin
+      expect(response.status).toBe(403)
+      expect(allowOrigin).toBe(origin)
+      const text = await response.text()
+      expect(text).toContain('Forbidden')
     }
   })
 })

--- a/proxy/test/security.test.js
+++ b/proxy/test/security.test.js
@@ -214,9 +214,9 @@ describe('Security - CORS Bypass Attempts', () => {
     // Null origin
     { origin: 'null', description: 'null origin' },
     // Origin with trailing characters
-    { origin: 'http://localhost:5173.evil.com', description: 'subdomain trick', disallowedEcho: true },
+    { origin: 'http://localhost:5173.evil.com', description: 'subdomain trick' },
     // Origin manipulation
-    { origin: 'http://localhost:5173%00.evil.com', description: 'null byte in origin', disallowedEcho: true },
+    { origin: 'http://localhost:5173%00.evil.com', description: 'null byte in origin' },
     // Case sensitivity
     { origin: 'HTTP://LOCALHOST:5173', description: 'uppercase origin' },
     // Whitespace
@@ -230,7 +230,7 @@ describe('Security - CORS Bypass Attempts', () => {
     { origin: 'http://127.0.0.1:5173', description: 'IP instead of localhost' },
   ]
 
-  it.each(bypassAttempts)('should handle origin: $description', async ({ origin, disallowedEcho }) => {
+  it.each(bypassAttempts)('should handle origin: $description', async ({ origin }) => {
     const response = await fetchWithMetrics('http://localhost/proxy/getAccessToken?code=test&redirect_uri=http://test.com', {
       method: 'POST',
       headers: { Origin: origin }
@@ -240,17 +240,18 @@ describe('Security - CORS Bypass Attempts', () => {
     // The key is it shouldn't crash and shouldn't allow unauthorized origins
     expect(response.status).toBeGreaterThanOrEqual(200)
 
-    // A disallowed origin may be echoed only on the static 403 rejection
-    // (lets the calling page read the error instead of a generic CORS
-    // failure) - never on a response carrying data. Match the echoed value
-    // exactly against the request origin rather than substring-scanning it.
-    if (disallowedEcho) {
-      const allowOrigin = response.headers.get('Access-Control-Allow-Origin')
-      if (allowOrigin === origin) {
-        expect(response.status).toBe(403)
-        const text = await response.text()
-        expect(text).toContain('Forbidden')
-      }
+    // Every origin in this suite is disallowed. A disallowed origin may be
+    // echoed back in Access-Control-Allow-Origin only on the static 403
+    // rejection (so the calling page can read the error) - never on a
+    // data-bearing response. Apply this to every bypass attempt and compare
+    // the echoed value exactly against the request origin (rather than
+    // substring-scanning it): by contrapositive, any non-403 response that
+    // reflected the disallowed origin would fail here, catching a regression.
+    const allowOrigin = response.headers.get('Access-Control-Allow-Origin')
+    if (allowOrigin === origin) {
+      expect(response.status).toBe(403)
+      const text = await response.text()
+      expect(text).toContain('Forbidden')
     }
   })
 })

--- a/proxy/test/security.test.js
+++ b/proxy/test/security.test.js
@@ -241,9 +241,13 @@ describe('Security - CORS Bypass Attempts', () => {
     expect(response.status).toBeGreaterThanOrEqual(200)
 
     const allowOrigin = response.headers.get('Access-Control-Allow-Origin')
-    // Should not echo back malicious origins
-    if (allowOrigin && allowOrigin !== '*') {
-      expect(allowOrigin).not.toContain('evil.com')
+    // A disallowed origin may be echoed only on the static 403 rejection
+    // (lets the calling page read the error instead of a generic CORS
+    // failure) - never on a response carrying data
+    if (allowOrigin && allowOrigin !== '*' && allowOrigin.includes('evil.com')) {
+      expect(response.status).toBe(403)
+      const text = await response.text()
+      expect(text).toContain('Forbidden')
     }
   })
 })
@@ -790,6 +794,22 @@ describe('Security - CSRF Protection', () => {
     expect(response.status).toBe(403)
     const text = await response.text()
     expect(text).toContain('Origin header required')
+  })
+
+  it('should include CORS headers on Origin-required rejections so clients can read the error', async () => {
+    const response = await fetchWithMetrics(
+      'http://localhost/proxy/getAccessToken?code=test&redirect_uri=http://localhost:5173',
+      {
+        method: 'POST'
+        // No Origin header
+      }
+    )
+
+    expect(response.status).toBe(403)
+    // No origin to echo, so '*' lets a stripped-Origin client read the
+    // explanation. Credentials must not be allowed with a wildcard origin.
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
+    expect(response.headers.get('Access-Control-Allow-Credentials')).toBeNull()
   })
 
   it('should reject DELETE request without Origin header', async () => {

--- a/proxy/test/security.test.js
+++ b/proxy/test/security.test.js
@@ -214,9 +214,9 @@ describe('Security - CORS Bypass Attempts', () => {
     // Null origin
     { origin: 'null', description: 'null origin' },
     // Origin with trailing characters
-    { origin: 'http://localhost:5173.evil.com', description: 'subdomain trick' },
+    { origin: 'http://localhost:5173.evil.com', description: 'subdomain trick', disallowedEcho: true },
     // Origin manipulation
-    { origin: 'http://localhost:5173%00.evil.com', description: 'null byte in origin' },
+    { origin: 'http://localhost:5173%00.evil.com', description: 'null byte in origin', disallowedEcho: true },
     // Case sensitivity
     { origin: 'HTTP://LOCALHOST:5173', description: 'uppercase origin' },
     // Whitespace
@@ -230,7 +230,7 @@ describe('Security - CORS Bypass Attempts', () => {
     { origin: 'http://127.0.0.1:5173', description: 'IP instead of localhost' },
   ]
 
-  it.each(bypassAttempts)('should handle origin: $description', async ({ origin }) => {
+  it.each(bypassAttempts)('should handle origin: $description', async ({ origin, disallowedEcho }) => {
     const response = await fetchWithMetrics('http://localhost/proxy/getAccessToken?code=test&redirect_uri=http://test.com', {
       method: 'POST',
       headers: { Origin: origin }
@@ -240,14 +240,17 @@ describe('Security - CORS Bypass Attempts', () => {
     // The key is it shouldn't crash and shouldn't allow unauthorized origins
     expect(response.status).toBeGreaterThanOrEqual(200)
 
-    const allowOrigin = response.headers.get('Access-Control-Allow-Origin')
     // A disallowed origin may be echoed only on the static 403 rejection
     // (lets the calling page read the error instead of a generic CORS
-    // failure) - never on a response carrying data
-    if (allowOrigin && allowOrigin !== '*' && allowOrigin.includes('evil.com')) {
-      expect(response.status).toBe(403)
-      const text = await response.text()
-      expect(text).toContain('Forbidden')
+    // failure) - never on a response carrying data. Match the echoed value
+    // exactly against the request origin rather than substring-scanning it.
+    if (disallowedEcho) {
+      const allowOrigin = response.headers.get('Access-Control-Allow-Origin')
+      if (allowOrigin === origin) {
+        expect(response.status).toBe(403)
+        const text = await response.text()
+        expect(text).toContain('Forbidden')
+      }
     }
   })
 })


### PR DESCRIPTION
## Summary

Promotes the merged changes from `develop` to `production`. Merging triggers the proxy deployment workflow (with automatic rollback on failure).

## Included changes

### PR #126 — CORS headers on 403 origin rejections (closes #125)
- The worker's two bare-403 paths (disallowed `Origin`, missing `Origin` on POST/DELETE) now carry CORS headers, so browsers can read the rejection body instead of reporting a generic CORS failure indistinguishable from edge errors.
- Invalid origin echoes the rejected origin (static body, grants nothing, re-validated per request); missing Origin uses `*` with no `Allow-Credentials`.

### PR #122 — CI/CD expression-injection hardening (closes #123)
- All `${{ }}` interpolations moved out of `run:` shell bodies into `env:` blocks in `deploy-proxy.yml` and `release.yml`; Slack payloads built with `jq -n --arg` (proper JSON escaping).
- `continue-on-error: true` on the release Slack step, `curl -sf` + `set -o pipefail` so notification failures are detected but never fail a release.

### PR #130 — review findings from this release PR + review-workflow repairs
- CORS-bypass test suite strengthened: every case asserts unconditionally (disallowed origins → static 403 echoing exactly the rejected origin; whitespace variants → proceed with exactly the allowlisted origin). Supersedes the Steward's interim `10a6370`.
- Dead `origin || '*'` fallback removed; static-body guard comment added at the invalid-origin 403.
- `Vary: Origin` added to CORS headers (cache correctness for reflected origins).
- `pr-review.yml`: `allowed_bots: "claude"` so PR Steward pushes no longer produce unpassable review checks.
- `pr-review-gemini.yml`: `GEMINI_CLI_TRUST_WORKSPACE=true` fixes the Gemini CLI's headless trust refusal (the cause of every "Gemini review unavailable"; remaining failures are upstream 503 capacity).

### Steward commits (reviewed and verified)
- `b3ffa95` — exact-match origin echo in the bypass test, clearing a high-severity CodeQL alert.
- `10a6370` — interim generalization of that check (subsumed by PR #130's version).

## Test results (local, on the final merged tree)

- proxy: 366 passed (vitest)
- admin: 18 passed (Playwright)
- demo1: 11 passed (Playwright)

## Versions

- proxy: 1.3.21 (changed — will deploy)
- admin: 1.1.4 (unchanged)
- demo1: 0.1.3 (unchanged)

## Follow-ups tracked separately

- #127 — optional CORS-403 hardening (remaining item: decide on dropping `Allow-Credentials` on rejections; the guard comment is done via PR #130)
- #128 — workflow hardening follow-ups from the PR #122 reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)