### PR TITLE
feat: Expand production test coverage (API checks, E2E prod mode, console guards)

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-admin",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-admin",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-admin",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-admin",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-admin",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-admin",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-admin",
   "displayName": "EEN OAuth Proxy Admin",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "private": true,
   "type": "module",
   "scripts": {
@@ -14,7 +14,8 @@
     "test:ui": "playwright test --ui",
     "test:headed": "playwright test --headed",
     "test:unit": "vitest run",
-    "test:unit:watch": "vitest"
+    "test:unit:watch": "vitest",
+    "test:prod": "E2E_PROD=1 VITE_PROXY_URL=$(grep \"^VITE_PROXY_URL\" .env.prod | cut -d= -f2-) playwright test"
   },
   "dependencies": {
     "pinia": "^3.0.4",

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-admin",
   "displayName": "EEN OAuth Proxy Admin",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "private": true,
   "type": "module",
   "scripts": {
@@ -15,7 +15,7 @@
     "test:headed": "playwright test --headed",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
-    "test:prod": "URL=$(grep \"^VITE_PROXY_URL=\" .env.prod | cut -d= -f2-); if [ -z \"$URL\" ]; then echo \"Error: VITE_PROXY_URL not found in .env.prod - refusing to run production tests against a fallback URL\" >&2; exit 1; fi; E2E_PROD=1 VITE_PROXY_URL=\"$URL\" playwright test"
+    "test:prod": "URL=$(grep \"^VITE_PROXY_URL=\" .env.prod | cut -d= -f2- | tr -d \"\\\"\\r\" ); if [ -z \"$URL\" ]; then echo \"Error: VITE_PROXY_URL not found in .env.prod - refusing to run production tests against a fallback URL\" >&2; exit 1; fi; E2E_PROD=1 VITE_PROXY_URL=\"$URL\" playwright test"
   },
   "dependencies": {
     "pinia": "^3.0.4",

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-admin",
   "displayName": "EEN OAuth Proxy Admin",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "private": true,
   "type": "module",
   "scripts": {
@@ -15,7 +15,7 @@
     "test:headed": "playwright test --headed",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
-    "test:prod": "E2E_PROD=1 VITE_PROXY_URL=$(grep \"^VITE_PROXY_URL\" .env.prod | cut -d= -f2-) playwright test"
+    "test:prod": "URL=$(grep \"^VITE_PROXY_URL=\" .env.prod | cut -d= -f2-); if [ -z \"$URL\" ]; then echo \"Error: VITE_PROXY_URL not found in .env.prod - refusing to run production tests against a fallback URL\" >&2; exit 1; fi; E2E_PROD=1 VITE_PROXY_URL=\"$URL\" playwright test"
   },
   "dependencies": {
     "pinia": "^3.0.4",

--- a/admin/playwright.config.js
+++ b/admin/playwright.config.js
@@ -29,8 +29,10 @@ export default defineConfig({
   ],
 
   // Run local dev server before tests
+  // E2E_PROD=1 (set by npm run test:prod) starts the app with production
+  // config so the tests run against the deployed proxy
   webServer: {
-    command: 'npm run dev',
+    command: process.env.E2E_PROD === '1' ? 'npm run dev:prod' : 'npm run dev',
     url: 'http://127.0.0.1:3333',
     reuseExistingServer: !process.env.CI,
     timeout: 120000,

--- a/admin/tests/admin-destructive.spec.js
+++ b/admin/tests/admin-destructive.spec.js
@@ -13,7 +13,7 @@
  * 2. Revoke all tokens
  */
 
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures.js'
 import {
   loginToAdmin,
   clearAppState,

--- a/admin/tests/admin-login.spec.js
+++ b/admin/tests/admin-login.spec.js
@@ -8,7 +8,7 @@
  * 4. Logout flow
  */
 
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures.js'
 import {
   loginToAdmin,
   logoutFromAdmin,

--- a/admin/tests/admin-session-revoke.spec.js
+++ b/admin/tests/admin-session-revoke.spec.js
@@ -1,0 +1,84 @@
+/**
+ * Admin Session Revoke Test (PRODUCTION-SAFE)
+ *
+ * Unlike admin-destructive.spec.js (mass removeSessions/revokeAll, local
+ * proxy only), this test only ever touches the session it creates itself:
+ * login, capture the session ID, revoke via "Logout & Revoke", then verify
+ * the captured session is truly dead server-side. Safe to run against any
+ * proxy, including production.
+ */
+
+import { test, expect } from './fixtures.js'
+import {
+  loginToAdmin,
+  clearAppState,
+  verifyOnDashboard,
+  getProxyUrl,
+  MAX_TEST_TIMEOUT
+} from './utils.js'
+
+test.describe('Admin Session Revoke (Production-Safe)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await clearAppState(page)
+  })
+
+  test('should revoke own session and reject it server-side afterwards', async ({ page, context }) => {
+    console.log('\n▶️ Running Test: Self-scoped session revoke\n')
+    test.setTimeout(MAX_TEST_TIMEOUT * 2)
+
+    const proxyUrl = getProxyUrl()
+    console.log(`📍 Proxy URL: ${proxyUrl}`)
+
+    // Step 1: Login (creates exactly one session - the only one this test touches)
+    await loginToAdmin(page)
+    await verifyOnDashboard(page)
+
+    // Step 2: Capture the session ID
+    const cookies = await context.cookies()
+    const sessionCookie = cookies.find((c) => c.name === 'sessionId')
+    expect(sessionCookie, 'Session cookie must exist after login').toBeTruthy()
+    const sessionId = sessionCookie.value
+    console.log('📋 Session ID captured: yes')
+
+    // Step 3: Verify the session works server-side before revoking
+    const beforeResponse = await fetch(`${proxyUrl}/admin/version`, {
+      headers: {
+        Origin: 'http://127.0.0.1:3333',
+        Authorization: `Bearer ${sessionId}`
+      }
+    })
+    expect(beforeResponse.status).toBe(200)
+    console.log('✅ Session valid before revoke (admin/version returned 200)')
+
+    // Step 4: Revoke own session via the UI
+    const revokeButton = page.getByRole('button', { name: 'Logout & Revoke' })
+    await revokeButton.click()
+    await page.waitForURL('/', { timeout: 15000 })
+    await expect(page.getByRole('button', { name: 'Sign in with Eagle Eye Networks' })).toBeVisible()
+    console.log('🚪 Logout & Revoke completed')
+
+    // Step 5: The captured session must now be rejected server-side
+    const afterAdmin = await fetch(`${proxyUrl}/admin/version`, {
+      headers: {
+        Origin: 'http://127.0.0.1:3333',
+        Authorization: `Bearer ${sessionId}`
+      }
+    })
+    expect(afterAdmin.status).toBe(401)
+    console.log('✅ Admin endpoint correctly rejected revoked session with 401')
+
+    const afterRefresh = await fetch(`${proxyUrl}/proxy/refreshAccessToken`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'http://127.0.0.1:3333',
+        Authorization: `Bearer ${sessionId}`
+      }
+    })
+    expect(afterRefresh.status).toBe(401)
+    console.log('✅ Token refresh correctly rejected revoked session with 401')
+
+    console.log('\n✅ Self-scoped session revoke test completed!\n')
+  })
+})

--- a/admin/tests/fixtures.js
+++ b/admin/tests/fixtures.js
@@ -1,0 +1,58 @@
+/**
+ * Shared Playwright fixtures
+ *
+ * Extends the base test so every page automatically collects uncaught
+ * exceptions and console errors, failing the test at teardown if any
+ * unexpected ones occurred. A CORS rejection, an uncaught exception, or a
+ * framework error in the browser fails the test even when the UI flow
+ * happens to succeed (the class of failure behind issue #125 surfaced only
+ * in the console).
+ */
+
+import { test as base, expect } from '@playwright/test'
+
+// Expected browser noise that must not fail tests:
+// - "Failed to load resource": negative-path tests deliberately trigger
+//   4xx responses, which Chromium always logs as a console error
+const IGNORED_CONSOLE_PATTERNS = [
+  /Failed to load resource/i
+]
+
+// Only errors raised by our own app should fail tests. During the OAuth
+// flow the page navigates to EEN's login site, whose scripts throw their
+// own uncaught exceptions - those are not ours to fix.
+const APP_ORIGINS = ['http://127.0.0.1:3333', 'http://localhost:3333']
+
+function isAppPage(page) {
+  const url = page.url()
+  return APP_ORIGINS.some((origin) => url.startsWith(origin))
+}
+
+export const test = base.extend({
+  // Tests that deliberately drive the app into an error path can declare
+  // the error messages they expect: test.use({ allowedConsoleErrors: [/.../] })
+  allowedConsoleErrors: [[], { option: true }],
+
+  page: async ({ page, allowedConsoleErrors }, use) => {
+    const errors = []
+    page.on('pageerror', (err) => {
+      if (!isAppPage(page)) return
+      if (allowedConsoleErrors.some((re) => re.test(err.message))) return
+      errors.push(`Uncaught exception: ${err.message}`)
+    })
+    page.on('console', (msg) => {
+      if (!isAppPage(page)) return
+      if (msg.type() !== 'error') return
+      const text = msg.text()
+      if (IGNORED_CONSOLE_PATTERNS.some((re) => re.test(text))) return
+      if (allowedConsoleErrors.some((re) => re.test(text))) return
+      errors.push(`Console error: ${text}`)
+    })
+
+    await use(page)
+
+    expect.soft(errors, 'Unexpected browser errors during test').toEqual([])
+  }
+})
+
+export { expect }

--- a/admin/tests/fixtures.js
+++ b/admin/tests/fixtures.js
@@ -7,6 +7,9 @@
  * framework error in the browser fails the test even when the UI flow
  * happens to succeed (the class of failure behind issue #125 surfaced only
  * in the console).
+ *
+ * NOTE: this file is duplicated in admin/tests/ and demo1/tests/ - keep
+ * both copies in sync.
  */
 
 import { test as base, expect } from '@playwright/test'
@@ -23,6 +26,10 @@ const IGNORED_CONSOLE_PATTERNS = [
 // own uncaught exceptions - those are not ours to fix.
 const APP_ORIGINS = ['http://127.0.0.1:3333', 'http://localhost:3333']
 
+// Caveat: page.url() reflects the URL at event-fire time, not where the
+// error originated, so an error landing mid-navigation can be misattributed.
+// Acceptable for this flow - errors during the brief OAuth redirects are
+// dropped rather than failing tests spuriously.
 function isAppPage(page) {
   const url = page.url()
   return APP_ORIGINS.some((origin) => url.startsWith(origin))

--- a/demo1/package-lock.json
+++ b/demo1/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-demo1",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-demo1",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/demo1/package-lock.json
+++ b/demo1/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-demo1",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-demo1",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/demo1/package-lock.json
+++ b/demo1/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-oauth-demo1",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-oauth-demo1",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.26",

--- a/demo1/package.json
+++ b/demo1/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-demo1",
   "displayName": "EEN OAuth Demo1",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "test": "playwright test",
     "test:ui": "playwright test --ui",
     "test:headed": "playwright test --headed",
-    "test:prod": "E2E_PROD=1 VITE_PROXY_URL=$(grep \"^VITE_PROXY_URL\" .env.prod | cut -d= -f2-) playwright test"
+    "test:prod": "URL=$(grep \"^VITE_PROXY_URL=\" .env.prod | cut -d= -f2-); if [ -z \"$URL\" ]; then echo \"Error: VITE_PROXY_URL not found in .env.prod - refusing to run production tests against a fallback URL\" >&2; exit 1; fi; E2E_PROD=1 VITE_PROXY_URL=\"$URL\" playwright test"
   },
   "dependencies": {
     "pinia": "^3.0.4",

--- a/demo1/package.json
+++ b/demo1/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-demo1",
   "displayName": "EEN OAuth Demo1",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "test": "playwright test",
     "test:ui": "playwright test --ui",
     "test:headed": "playwright test --headed",
-    "test:prod": "URL=$(grep \"^VITE_PROXY_URL=\" .env.prod | cut -d= -f2-); if [ -z \"$URL\" ]; then echo \"Error: VITE_PROXY_URL not found in .env.prod - refusing to run production tests against a fallback URL\" >&2; exit 1; fi; E2E_PROD=1 VITE_PROXY_URL=\"$URL\" playwright test"
+    "test:prod": "URL=$(grep \"^VITE_PROXY_URL=\" .env.prod | cut -d= -f2- | tr -d \"\\\"\\r\" ); if [ -z \"$URL\" ]; then echo \"Error: VITE_PROXY_URL not found in .env.prod - refusing to run production tests against a fallback URL\" >&2; exit 1; fi; E2E_PROD=1 VITE_PROXY_URL=\"$URL\" playwright test"
   },
   "dependencies": {
     "pinia": "^3.0.4",

--- a/demo1/package.json
+++ b/demo1/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-oauth-demo1",
   "displayName": "EEN OAuth Demo1",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "scripts": {
@@ -12,7 +12,8 @@
     "preview": "vite preview",
     "test": "playwright test",
     "test:ui": "playwright test --ui",
-    "test:headed": "playwright test --headed"
+    "test:headed": "playwright test --headed",
+    "test:prod": "E2E_PROD=1 VITE_PROXY_URL=$(grep \"^VITE_PROXY_URL\" .env.prod | cut -d= -f2-) playwright test"
   },
   "dependencies": {
     "pinia": "^3.0.4",

--- a/demo1/playwright.config.js
+++ b/demo1/playwright.config.js
@@ -29,8 +29,10 @@ export default defineConfig({
   ],
 
   // Run local dev server before tests
+  // E2E_PROD=1 (set by npm run test:prod) starts the app with production
+  // config so the tests run against the deployed proxy
   webServer: {
-    command: 'npm run dev',
+    command: process.env.E2E_PROD === '1' ? 'npm run dev:prod' : 'npm run dev',
     url: 'http://127.0.0.1:3333',
     reuseExistingServer: !process.env.CI,
     timeout: 120000,

--- a/demo1/src/views/Profile.vue
+++ b/demo1/src/views/Profile.vue
@@ -285,14 +285,16 @@ async function fetchUserProfile() {
 
 function copyToClipboard(text) {
   if (text) {
-    navigator.clipboard.writeText(text)
+    // Clipboard access can be denied (permissions, insecure context) - the
+    // copy is a convenience, not worth an uncaught rejection
+    navigator.clipboard.writeText(text).catch(() => {})
   }
 }
 
 function toggleAndCopyToken() {
   showToken.value = !showToken.value
   if (showToken.value && authStore.token) {
-    navigator.clipboard.writeText(authStore.token)
+    navigator.clipboard.writeText(authStore.token).catch(() => {})
   }
 }
 

--- a/demo1/tests/auth-flows.spec.js
+++ b/demo1/tests/auth-flows.spec.js
@@ -8,7 +8,7 @@
  * 4. Token refresh and direct login with refreshed token
  */
 
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures.js'
 import {
   navigateToLogin,
   loginWithEEN,
@@ -262,9 +262,14 @@ test.describe('Authentication Flows', () => {
     console.log('\n✅ Old token behavior test completed!\n')
   })
 
-  test('should fail login if OAuth state is invalid (CSRF protection)', async ({ page }) => {
-    console.log('\n▶️ Running Test: Invalid OAuth state (CSRF)\n')
-    test.setTimeout(MAX_TEST_TIMEOUT)
+  test.describe('with expected OAuth state rejection', () => {
+    // This test deliberately presents an invalid OAuth state; the app logs
+    // the rejection via console.error, which is the behavior under test
+    test.use({ allowedConsoleErrors: [/Invalid OAuth state/] })
+
+    test('should fail login if OAuth state is invalid (CSRF protection)', async ({ page }) => {
+      console.log('\n▶️ Running Test: Invalid OAuth state (CSRF)\n')
+      test.setTimeout(MAX_TEST_TIMEOUT)
 
     // Step 1: Inject a known 'state' into sessionStorage, simulating the start of a login flow
     await page.goto('/')
@@ -346,5 +351,6 @@ test.describe('Authentication Flows', () => {
     console.log('✅ Confirmed not redirected to profile')
 
     console.log('\n✅ Missing state protection test completed!\n')
+  })
   })
 })

--- a/demo1/tests/auth-flows.spec.js
+++ b/demo1/tests/auth-flows.spec.js
@@ -262,95 +262,95 @@ test.describe('Authentication Flows', () => {
     console.log('\n✅ Old token behavior test completed!\n')
   })
 
+  // Both CSRF tests below deliberately present a bad OAuth state; the app
+  // logs the rejection via console.error, which is the behavior under test
   test.describe('with expected OAuth state rejection', () => {
-    // This test deliberately presents an invalid OAuth state; the app logs
-    // the rejection via console.error, which is the behavior under test
     test.use({ allowedConsoleErrors: [/Invalid OAuth state/] })
 
     test('should fail login if OAuth state is invalid (CSRF protection)', async ({ page }) => {
       console.log('\n▶️ Running Test: Invalid OAuth state (CSRF)\n')
       test.setTimeout(MAX_TEST_TIMEOUT)
 
-    // Step 1: Inject a known 'state' into sessionStorage, simulating the start of a login flow
-    await page.goto('/')
-    await page.evaluate(() => {
-      sessionStorage.setItem('oauth_state', 'my-secret-test-state')
-    })
-    console.log('🤫 Injected known state into sessionStorage')
+      // Step 1: Inject a known 'state' into sessionStorage, simulating the start of a login flow
+      await page.goto('/')
+      await page.evaluate(() => {
+        sessionStorage.setItem('oauth_state', 'my-secret-test-state')
+      })
+      console.log('🤫 Injected known state into sessionStorage')
 
-    // Step 2: Intercept the getAccessToken call to prevent it from failing on the fake code
-    await page.route('**/proxy/getAccessToken*', async (route) => {
-      console.log('➡️ Intercepted getAccessToken call')
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          accessToken: 'fake-token-for-testing',
-          expiresIn: 3600,
-          userEmail: 'test@example.com'
+      // Step 2: Intercept the getAccessToken call to prevent it from failing on the fake code
+      await page.route('**/proxy/getAccessToken*', async (route) => {
+        console.log('➡️ Intercepted getAccessToken call')
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            accessToken: 'fake-token-for-testing',
+            expiresIn: 3600,
+            userEmail: 'test@example.com'
+          })
         })
       })
+
+      // Step 3: Navigate to the callback URL with a valid-looking code but an *invalid* state
+      const callbackUrl = `/?code=fake-code-for-csrf-test&state=this-is-wrong`
+      await page.goto(callbackUrl)
+      console.log(`🔀 Navigated to callback with invalid state: ${callbackUrl}`)
+
+      // Step 4: Check for the specific CSRF error message
+      // The app should detect the state mismatch and show an error.
+      await expect(page.locator('text=Invalid OAuth state')).toBeVisible({ timeout: 10000 })
+      console.log('✅ Error message displayed for invalid state')
+
+      // Verify we are still on the login page and not redirected
+      const currentUrl = page.url()
+      expect(currentUrl).not.toContain('/profile')
+      console.log('✅ Confirmed not redirected to profile')
+
+      console.log('\n✅ CSRF (state) protection test completed!\n')
     })
 
-    // Step 3: Navigate to the callback URL with a valid-looking code but an *invalid* state
-    const callbackUrl = `/?code=fake-code-for-csrf-test&state=this-is-wrong`
-    await page.goto(callbackUrl)
-    console.log(`🔀 Navigated to callback with invalid state: ${callbackUrl}`)
+    test('should fail login if OAuth state is missing (CSRF protection)', async ({ page }) => {
+      console.log('\n▶️ Running Test: Missing OAuth state (CSRF)\n')
+      test.setTimeout(MAX_TEST_TIMEOUT)
 
-    // Step 4: Check for the specific CSRF error message
-    // The app should detect the state mismatch and show an error.
-    await expect(page.locator('text=Invalid OAuth state')).toBeVisible({ timeout: 10000 })
-    console.log('✅ Error message displayed for invalid state')
+      // Step 1: Inject a known 'state' into sessionStorage, simulating the start of a login flow
+      await page.goto('/')
+      await page.evaluate(() => {
+        sessionStorage.setItem('oauth_state', 'my-secret-test-state')
+      })
+      console.log('🤫 Injected known state into sessionStorage')
 
-    // Verify we are still on the login page and not redirected
-    const currentUrl = page.url()
-    expect(currentUrl).not.toContain('/profile')
-    console.log('✅ Confirmed not redirected to profile')
-
-    console.log('\n✅ CSRF (state) protection test completed!\n')
-  })
-
-  test('should fail login if OAuth state is missing (CSRF protection)', async ({ page }) => {
-    console.log('\n▶️ Running Test: Missing OAuth state (CSRF)\n')
-    test.setTimeout(MAX_TEST_TIMEOUT)
-
-    // Step 1: Inject a known 'state' into sessionStorage, simulating the start of a login flow
-    await page.goto('/')
-    await page.evaluate(() => {
-      sessionStorage.setItem('oauth_state', 'my-secret-test-state')
-    })
-    console.log('🤫 Injected known state into sessionStorage')
-
-    // Step 2: Intercept the getAccessToken call to prevent it from failing on the fake code
-    await page.route('**/proxy/getAccessToken*', async (route) => {
-      console.log('➡️ Intercepted getAccessToken call')
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          accessToken: 'fake-token-for-testing',
-          expiresIn: 3600,
-          userEmail: 'test@example.com'
+      // Step 2: Intercept the getAccessToken call to prevent it from failing on the fake code
+      await page.route('**/proxy/getAccessToken*', async (route) => {
+        console.log('➡️ Intercepted getAccessToken call')
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            accessToken: 'fake-token-for-testing',
+            expiresIn: 3600,
+            userEmail: 'test@example.com'
+          })
         })
       })
+
+      // Step 3: Navigate to the callback URL with a code but NO state parameter
+      const callbackUrl = `/?code=fake-code-for-csrf-test`
+      await page.goto(callbackUrl)
+      console.log(`🔀 Navigated to callback with missing state: ${callbackUrl}`)
+
+      // Step 4: Check for the specific CSRF error message
+      // The app should detect the missing state and show an error.
+      await expect(page.locator('text=Invalid OAuth state')).toBeVisible({ timeout: 10000 })
+      console.log('✅ Error message displayed for missing state')
+
+      // Verify we are still on the login page and not redirected
+      const currentUrl = page.url()
+      expect(currentUrl).not.toContain('/profile')
+      console.log('✅ Confirmed not redirected to profile')
+
+      console.log('\n✅ Missing state protection test completed!\n')
     })
-
-    // Step 3: Navigate to the callback URL with a code but NO state parameter
-    const callbackUrl = `/?code=fake-code-for-csrf-test`
-    await page.goto(callbackUrl)
-    console.log(`🔀 Navigated to callback with missing state: ${callbackUrl}`)
-
-    // Step 4: Check for the specific CSRF error message
-    // The app should detect the missing state and show an error.
-    await expect(page.locator('text=Invalid OAuth state')).toBeVisible({ timeout: 10000 })
-    console.log('✅ Error message displayed for missing state')
-
-    // Verify we are still on the login page and not redirected
-    const currentUrl = page.url()
-    expect(currentUrl).not.toContain('/profile')
-    console.log('✅ Confirmed not redirected to profile')
-
-    console.log('\n✅ Missing state protection test completed!\n')
-  })
   })
 })

--- a/demo1/tests/fixtures.js
+++ b/demo1/tests/fixtures.js
@@ -1,0 +1,58 @@
+/**
+ * Shared Playwright fixtures
+ *
+ * Extends the base test so every page automatically collects uncaught
+ * exceptions and console errors, failing the test at teardown if any
+ * unexpected ones occurred. A CORS rejection, an uncaught exception, or a
+ * framework error in the browser fails the test even when the UI flow
+ * happens to succeed (the class of failure behind issue #125 surfaced only
+ * in the console).
+ */
+
+import { test as base, expect } from '@playwright/test'
+
+// Expected browser noise that must not fail tests:
+// - "Failed to load resource": negative-path tests deliberately trigger
+//   4xx responses, which Chromium always logs as a console error
+const IGNORED_CONSOLE_PATTERNS = [
+  /Failed to load resource/i
+]
+
+// Only errors raised by our own app should fail tests. During the OAuth
+// flow the page navigates to EEN's login site, whose scripts throw their
+// own uncaught exceptions - those are not ours to fix.
+const APP_ORIGINS = ['http://127.0.0.1:3333', 'http://localhost:3333']
+
+function isAppPage(page) {
+  const url = page.url()
+  return APP_ORIGINS.some((origin) => url.startsWith(origin))
+}
+
+export const test = base.extend({
+  // Tests that deliberately drive the app into an error path can declare
+  // the error messages they expect: test.use({ allowedConsoleErrors: [/.../] })
+  allowedConsoleErrors: [[], { option: true }],
+
+  page: async ({ page, allowedConsoleErrors }, use) => {
+    const errors = []
+    page.on('pageerror', (err) => {
+      if (!isAppPage(page)) return
+      if (allowedConsoleErrors.some((re) => re.test(err.message))) return
+      errors.push(`Uncaught exception: ${err.message}`)
+    })
+    page.on('console', (msg) => {
+      if (!isAppPage(page)) return
+      if (msg.type() !== 'error') return
+      const text = msg.text()
+      if (IGNORED_CONSOLE_PATTERNS.some((re) => re.test(text))) return
+      if (allowedConsoleErrors.some((re) => re.test(text))) return
+      errors.push(`Console error: ${text}`)
+    })
+
+    await use(page)
+
+    expect.soft(errors, 'Unexpected browser errors during test').toEqual([])
+  }
+})
+
+export { expect }

--- a/demo1/tests/fixtures.js
+++ b/demo1/tests/fixtures.js
@@ -7,6 +7,9 @@
  * framework error in the browser fails the test even when the UI flow
  * happens to succeed (the class of failure behind issue #125 surfaced only
  * in the console).
+ *
+ * NOTE: this file is duplicated in admin/tests/ and demo1/tests/ - keep
+ * both copies in sync.
  */
 
 import { test as base, expect } from '@playwright/test'
@@ -23,6 +26,10 @@ const IGNORED_CONSOLE_PATTERNS = [
 // own uncaught exceptions - those are not ours to fix.
 const APP_ORIGINS = ['http://127.0.0.1:3333', 'http://localhost:3333']
 
+// Caveat: page.url() reflects the URL at event-fire time, not where the
+// error originated, so an error landing mid-navigation can be misattributed.
+// Acceptable for this flow - errors during the brief OAuth redirects are
+// dropped rather than failing tests spuriously.
 function isAppPage(page) {
   const url = page.url()
   return APP_ORIGINS.some((origin) => url.startsWith(origin))

--- a/demo1/tests/happy-path.spec.js
+++ b/demo1/tests/happy-path.spec.js
@@ -9,7 +9,7 @@
  * 5. Logout and verify return to login page
  */
 
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures.js'
 import { loginToApplication, logoutFromApplication, captureCredentialsFromProfile, MAX_TEST_TIMEOUT } from './utils.js'
 
 test.describe('Happy Path - OAuth Login Flow', () => {

--- a/scripts/test-e2e-production.sh
+++ b/scripts/test-e2e-production.sh
@@ -33,8 +33,15 @@ NC='\033[0m'
 FAILED=0
 
 cleanup() {
-  # Stop whatever is on the app port; the apps' own npm scripts also do this
-  lsof -ti :3333 2>/dev/null | xargs kill 2>/dev/null || true
+  # Stop the dev servers the test runs spawn. Only node/vite processes are
+  # killed so an unrelated process that happens to own port 3333 is left
+  # alone, and the whole step is skipped when lsof is unavailable.
+  command -v lsof >/dev/null 2>&1 || return 0
+  for pid in $(lsof -ti :3333 2>/dev/null); do
+    if ps -o comm= -p "$pid" 2>/dev/null | grep -qE 'node|vite'; then
+      kill "$pid" 2>/dev/null || true
+    fi
+  done
 }
 trap cleanup EXIT
 

--- a/scripts/test-e2e-production.sh
+++ b/scripts/test-e2e-production.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+# Production E2E Tests
+#
+# Runs the full production verification suite against the deployed proxy:
+#   1. API tests (scripts/test-production-proxy.sh) - read-only curl checks
+#   2. demo1 Playwright E2E in production mode (real OAuth logins)
+#   3. admin Playwright E2E in production mode
+#
+# The apps run locally on port 3333 in production config (npm run dev:prod),
+# talking to the deployed proxy. Destructive admin tests skip automatically
+# against a non-local proxy; the self-scoped session-revoke test still runs
+# and only ever touches the session it creates.
+#
+# Requirements: TEST_USER/TEST_PASSWORD (demo1/.env) and
+# ADMIN_TEST_USER/ADMIN_TEST_PASSWORD (admin/.env) must be valid EEN
+# credentials, since logins go against the real EEN OAuth service.
+#
+# Usage:
+#   ./scripts/test-e2e-production.sh
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+FAILED=0
+
+cleanup() {
+  # Stop whatever is on the app port; the apps' own npm scripts also do this
+  lsof -ti :3333 2>/dev/null | xargs kill 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo -e "${BLUE}=== 1/3 Production proxy API tests ===${NC}"
+if ! BRIEF=1 "$SCRIPT_DIR/test-production-proxy.sh"; then
+  FAILED=1
+fi
+
+echo -e "\n${BLUE}=== 2/3 demo1 E2E against production ===${NC}"
+cleanup
+if ! (cd "$ROOT_DIR/demo1" && npm run test:prod); then
+  FAILED=1
+fi
+
+echo -e "\n${BLUE}=== 3/3 admin E2E against production ===${NC}"
+cleanup
+if ! (cd "$ROOT_DIR/admin" && npm run test:prod); then
+  FAILED=1
+fi
+
+echo ""
+if [ $FAILED -eq 0 ]; then
+  echo -e "${GREEN}All production test suites passed${NC}"
+  exit 0
+else
+  echo -e "${RED}One or more production test suites failed${NC}"
+  exit 1
+fi

--- a/scripts/test-production-proxy.sh
+++ b/scripts/test-production-proxy.sh
@@ -151,6 +151,8 @@ INVALID_ORIGIN_HEADERS=$(curl -s -i --max-time 10 "$PROXY_URL/health" \
   -H "Origin: https://malicious-site.com" 2>/dev/null || echo "")
 run_test_contains "403 echoes rejected origin in ACAO" "access-control-allow-origin: https://malicious-site.com" "$INVALID_ORIGIN_HEADERS"
 run_test_contains "403 includes Vary: Origin" "vary: origin" "$INVALID_ORIGIN_HEADERS"
+# Note: $(...) strips the trailing newline, which is what makes the exact
+# string comparison below work
 INVALID_ORIGIN_BODY=$(curl -s --max-time 10 "$PROXY_URL/health" \
   -H "Origin: https://malicious-site.com" 2>/dev/null || echo "")
 run_test "403 body is the exact static string" "Forbidden: Invalid origin" "$INVALID_ORIGIN_BODY"

--- a/scripts/test-production-proxy.sh
+++ b/scripts/test-production-proxy.sh
@@ -73,6 +73,20 @@ run_test_contains() {
   fi
 }
 
+run_test_not_contains() {
+  local test_name="$1"
+  local needle="$2"
+  local haystack="$3"
+
+  if echo "$haystack" | grep -qi "$needle"; then
+    [ "$BRIEF" = "1" ] && echo -e "${RED}✗${NC} $test_name" || echo -e "   ${RED}❌ FAILED${NC} - $test_name (unexpected: $needle)"
+    ((FAILED++)) || true
+  else
+    [ "$BRIEF" = "1" ] && echo -e "${GREEN}✓${NC} $test_name" || echo -e "   ${GREEN}✅ PASSED${NC} - $test_name"
+    ((PASSED++)) || true
+  fi
+}
+
 if [ "$BRIEF" = "1" ]; then
   echo -e "${BLUE}Production Proxy Tests${NC} - $PROXY_URL"
 else
@@ -120,12 +134,26 @@ run_test_contains "X-Content-Type-Options header" "x-content-type-options" "$SEC
 run_test_contains "X-Frame-Options header" "x-frame-options" "$SECURITY_HEADERS"
 run_test_contains "Content-Security-Policy header" "content-security-policy" "$SECURITY_HEADERS"
 run_test_contains "Referrer-Policy header" "referrer-policy" "$SECURITY_HEADERS"
+# HSTS is only set outside development, so production is the only place to test it
+run_test_contains "Strict-Transport-Security header" "strict-transport-security" "$SECURITY_HEADERS"
+run_test_contains "Vary: Origin header" "vary: origin" "$SECURITY_HEADERS"
 
 # 5. Reject Invalid Origin
 [ "$BRIEF" != "1" ] && echo -e "\n${BLUE}5. Reject Invalid Origin${NC}"
 INVALID_ORIGIN=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$PROXY_URL/health" \
   -H "Origin: https://malicious-site.com" 2>/dev/null || echo "000")
 run_test "Invalid origin rejected" "403" "$INVALID_ORIGIN"
+
+# The 403 must be readable by the calling page (issue #125): CORS headers echo
+# the rejected origin, and the body must stay the exact static string - it is
+# readable cross-origin with credentials, so any dynamic content would leak
+INVALID_ORIGIN_HEADERS=$(curl -s -i --max-time 10 "$PROXY_URL/health" \
+  -H "Origin: https://malicious-site.com" 2>/dev/null || echo "")
+run_test_contains "403 echoes rejected origin in ACAO" "access-control-allow-origin: https://malicious-site.com" "$INVALID_ORIGIN_HEADERS"
+run_test_contains "403 includes Vary: Origin" "vary: origin" "$INVALID_ORIGIN_HEADERS"
+INVALID_ORIGIN_BODY=$(curl -s --max-time 10 "$PROXY_URL/health" \
+  -H "Origin: https://malicious-site.com" 2>/dev/null || echo "")
+run_test "403 body is the exact static string" "Forbidden: Invalid origin" "$INVALID_ORIGIN_BODY"
 
 # 6. Missing Session Returns 401
 [ "$BRIEF" != "1" ] && echo -e "\n${BLUE}6. Authentication - Missing Session${NC}"
@@ -168,6 +196,37 @@ run_test "getAccessToken endpoint exists (400 without params)" "400" "$OAUTH_GET
 OAUTH_REVOKE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 -X POST "$PROXY_URL/proxy/revoke" \
   -H "Origin: $ALLOWED_ORIGIN" 2>/dev/null || echo "000")
 run_test "revoke endpoint exists (401 without session)" "401" "$OAUTH_REVOKE"
+
+# 11. CSRF Protection - POST Without Origin
+[ "$BRIEF" != "1" ] && echo -e "\n${BLUE}11. CSRF Protection - POST Without Origin${NC}"
+CSRF_RESPONSE=$(curl -s -i --max-time 10 -X POST "$PROXY_URL/proxy/getAccessToken" 2>/dev/null || echo "")
+CSRF_STATUS=$(echo "$CSRF_RESPONSE" | head -1 | grep -oE '[0-9]{3}' | head -1)
+run_test "POST without Origin rejected" "403" "$CSRF_STATUS"
+# The wildcard lets a stripped-Origin client read the explanation, but
+# credentials must never be allowed together with a wildcard origin
+run_test_contains "CSRF 403 has wildcard ACAO" "access-control-allow-origin: \*" "$CSRF_RESPONSE"
+run_test_not_contains "CSRF 403 has no Allow-Credentials" "access-control-allow-credentials" "$CSRF_RESPONSE"
+
+# 12. Preflight From Disallowed Origin
+[ "$BRIEF" != "1" ] && echo -e "\n${BLUE}12. Preflight From Disallowed Origin${NC}"
+BAD_PREFLIGHT=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 -X OPTIONS "$PROXY_URL/proxy/getAccessToken" \
+  -H "Origin: https://malicious-site.com" \
+  -H "Access-Control-Request-Method: POST" 2>/dev/null || echo "000")
+run_test "Preflight from disallowed origin rejected" "403" "$BAD_PREFLIGHT"
+
+# 13. Token Responses Are Not Cacheable (RFC 6749 Section 5.1)
+[ "$BRIEF" != "1" ] && echo -e "\n${BLUE}13. Token Responses Not Cacheable${NC}"
+REFRESH_401=$(curl -s -i --max-time 10 -X POST "$PROXY_URL/proxy/refreshAccessToken" \
+  -H "Origin: $ALLOWED_ORIGIN" 2>/dev/null || echo "")
+run_test_contains "Refresh 401 has Cache-Control: no-store" "cache-control: no-store" "$REFRESH_401"
+run_test_contains "Refresh 401 has Pragma: no-cache" "pragma: no-cache" "$REFRESH_401"
+
+# 14. Disallowed redirect_uri Rejected
+[ "$BRIEF" != "1" ] && echo -e "\n${BLUE}14. Redirect URI Validation${NC}"
+BAD_REDIRECT=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 -X POST \
+  "$PROXY_URL/proxy/getAccessToken?code=test&redirect_uri=https://evil.example.com" \
+  -H "Origin: $ALLOWED_ORIGIN" 2>/dev/null || echo "000")
+run_test "Disallowed redirect_uri rejected" "400" "$BAD_REDIRECT"
 
 # Summary
 if [ "$BRIEF" = "1" ]; then


### PR DESCRIPTION
## Summary

Implements the full set of production-testing improvements discussed after the v1.3.21 release: 12 new API checks, a production-safe destructive E2E test, browser console-error guards, and one-command production E2E orchestration.

## Production API script — 17 → 29 checks

`scripts/test-production-proxy.sh` now also verifies:
- **Invalid-origin 403 readability** (issue #125 feature): echoes the rejected origin in ACAO, carries `Vary: Origin`, and the body is the **exact** static string (production twin of #131's invariant).
- **CSRF 403** (POST without Origin): wildcard ACAO **without** `Allow-Credentials` (new `run_test_not_contains` helper).
- **Preflight from a disallowed origin** is rejected (403, not 204).
- **HSTS** — only testable here, since dev omits it — and `Vary: Origin` on normal responses.
- **`Cache-Control: no-store` + `Pragma: no-cache`** on the refresh 401 (RFC 6749 §5.1; matches what `2a20dc9` implemented — validation 400s intentionally don't carry it).
- **Disallowed `redirect_uri` → 400.**

All assertions were verified against live production behavior before being encoded. The deploy workflow already runs this script post-deploy (`deploy-proxy.yml:227`), so these checks strengthen the deployment gate automatically.

## Playwright

- **`admin/tests/admin-session-revoke.spec.js`** (new, production-safe): login → capture session → "Logout & Revoke" → verify the captured session gets 401 from both an admin endpoint and token refresh. Unlike the mass-destructive suite (which still skips on non-local proxies), this only ever touches its own session. Verified against production.
- **Console-error guard** (`tests/fixtures.js` in both apps): uncaught page exceptions and unexpected `console.error`s fail the test. Scoped to the app origin (EEN's login page throws its own uncaught errors during OAuth) with `Failed to load resource` ignored (negative-path 4xx noise) and a per-test `test.use({ allowedConsoleErrors })` opt-out, used by the two CSRF tests that deliberately trigger the app's state-rejection error.
- **The guard caught a real bug**: unhandled `clipboard.writeText` rejection in demo1's Profile view (fails in permission-denied contexts). Fixed with `.catch(() => {})` — the copy is a convenience.
- **`npm run test:prod`** in both apps: `E2E_PROD=1` switches the Playwright webServer to `dev:prod` and points the tests at the proxy URL from `.env.prod`.
- **`scripts/test-e2e-production.sh`**: one command for the whole production verification — API checks + demo1 E2E + admin E2E sequentially (apps share port 3333).

## Test results

- Production: API script 29/29; demo1 11/11; admin 14 passed + 5 intentionally skipped (mass-destructive) — via the new orchestrator
- Local: proxy 366/366 (vitest); demo1 11/11; admin 19/19 (18 + new revoke spec)

## Versions

- demo1: 0.1.4, admin: 1.1.5 (hook bumps); proxy: 1.3.21 (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)